### PR TITLE
gel-python 3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - run: pip install cibuildwheel==2.19.1
+      - run: pip install cibuildwheel==2.22.0
       - id: set-matrix
         # Cannot test on Musl distros yet.
         run: |
@@ -135,7 +135,7 @@ jobs:
     - name: Install EdgeDB
       uses: edgedb/setup-edgedb@v1
 
-    - uses: pypa/cibuildwheel@v2.19.1
+    - uses: pypa/cibuildwheel@v2.22.0
       with:
           only: ${{ matrix.only }}
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: dist
+        name: dist-version
         path: dist/
 
   build-sdist:
@@ -71,7 +71,7 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: dist
+        name: dist-source
         path: dist/*.tar.*
 
   build-wheels-matrix:
@@ -155,7 +155,7 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: dist
+        name: dist-wheel-${{ matrix.only }}
         path: wheelhouse/*.whl
 
   publish:
@@ -179,8 +179,9 @@ jobs:
 
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: dist
         path: dist/
+        pattern: dist-*
+        merge-multiple: true
 
     - name: Extract Release Version
       id: relver

--- a/gel/_version.py
+++ b/gel/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = "3.0.0b7"
+__version__ = "3.0.0"


### PR DESCRIPTION
EdgeDB has been renamed to Gel, and so has this python package.

Changes
=======

* Rename the package to gel! The package still provides an ``edgedb``
  module in addition to ``gel``, but ``gel`` is now preferred.
  (by @msullivan in 83349d4e for #566)

* Allow cloud instance names to contain '-' and '_' in the org part to support vercel instances
  (by @msullivan in 5b5be683 for #1084)

* Support specifying SNI tls_server_name
  (by @msullivan in 6b28b989 for #1088)

* Support GEL_ env vars and gel.toml
  (by @msullivan in d0b39616 for #532)

* Add support for protocol 3.0
  (by @elprans in 2e6a8778 for #534)

* Add support for newly exposed Postgres types
  (by @elprans in 48a67c16)

* Kill pre-1.0 forever deprecated API / dead code.
  (by @1st1 in 8669e78d)

* Rename main module from edgedb to gel
  (by @msullivan in 10d61a15 for #544)

* Support the gel:// dsn protocol
  (by @msullivan in 84c533c7 for #546)

* Add a way to export SQLAlchemy models from Gel (EdgeDB).
  (by @vpetrovykh in 645fce0a for #536)

* Implement gel.Record type
  (by @1st1 in ff3aad25 for #560)

* Add ORM model generators for Django, SQLAlchemy, sqlmodel.
  (by @vpetrovykh in ad37a6b3)

* Add support for REPEATABLE READ isolation (requires server support)
  (by @elprans in 8f40d0ea for #565)

* Retry calls to `execute` as well as to `query`
  (by @msullivan in e263f2b5 for #577)

* Add support for running (and installing) the main CLI
  (by @elprans in 023697a8 for #572)

* Rename AI to RAGClient and add compat names
  (by @fantix in e5aae27f for #578)