### PR TITLE
Update upload-artifact and download-artifact actions to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         mkdir -p dist/
         echo "${VERSION}" > dist/VERSION
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: dist
         path: dist/
@@ -69,7 +69,7 @@ jobs:
         pip install -U setuptools wheel pip
         python setup.py sdist
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: dist
         path: dist/*.tar.*
@@ -153,7 +153,7 @@ jobs:
           && chmod -R go+rX "$(dirname $(dirname $(dirname $PY)))"
           && su -l edgedb -c "EDGEDB_PYTHON_TEST_CODEGEN_CMD=$CODEGEN EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX=.assert${{ env.EDGEDB_SERVER_VERSION }} $PY {project}/tests/__init__.py"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: dist
         path: wheelhouse/*.whl
@@ -177,7 +177,7 @@ jobs:
         fetch-depth: 5
         submodules: false
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: dist
         path: dist/


### PR DESCRIPTION
v3 has been disabled now apparently.