### PR TITLE
Update SQLModel generator.

### DIFF
--- a/gel/orm/django/generator.py
+++ b/gel/orm/django/generator.py
@@ -138,7 +138,7 @@ class ModelGenerator(FilePrinter):
             # process properties as fields
             for prop in rec['properties']:
                 pname = prop['name']
-                if pname == 'id' or prop['cardinality'] == 'Many':
+                if prop['cardinality'] == 'Many':
                     continue
 
                 code = self.render_prop(prop)

--- a/gel/orm/introspection.py
+++ b/gel/orm/introspection.py
@@ -42,7 +42,7 @@ select ObjectType {
             filter .name = 'std::exclusive'
         ),
         target: {name},
-    } filter not exists .expr,
+    } filter .name != 'id' and not exists .expr,
     backlinks := <array<str>>[],
 }
 filter

--- a/gel/orm/sqla.py
+++ b/gel/orm/sqla.py
@@ -293,8 +293,7 @@ class ModelGenerator(FilePrinter):
             self.write('# Properties:')
 
             for prop in spec['properties']:
-                if prop['name'] != 'id':
-                    self.render_prop(prop, mod, name, {})
+                self.render_prop(prop, mod, name, {})
 
         self.dedent()
 
@@ -340,8 +339,7 @@ class ModelGenerator(FilePrinter):
 
             properties = sorted(spec['properties'], key=field_name_sort)
             for prop in properties:
-                if prop['name'] != 'id':
-                    self.render_prop(prop, mod, name, modules)
+                self.render_prop(prop, mod, name, modules)
 
         if spec['links']:
             self.write()

--- a/gel/orm/sqlmodel.py
+++ b/gel/orm/sqlmodel.py
@@ -107,6 +107,7 @@ class ModelGenerator(FilePrinter):
             try:
                 self.out = f
                 self.write(f'{COMMENT}\n')
+                self.write(f'from typing import Optional')
                 self.write(f'from {self.basemodule}._tables import *')
                 yield f
             finally:
@@ -182,7 +183,6 @@ class ModelGenerator(FilePrinter):
             self.write(MODELS_STUB)
 
             for rec in spec['link_tables']:
-                self.write()
                 self.render_link_table(rec)
 
         for mod, maps in modules.items():
@@ -204,6 +204,8 @@ class ModelGenerator(FilePrinter):
                     key=lambda x: x['name']
                 )
                 for rec in maps.get('object_types', {}).values():
+                    self.write()
+                    self.render_base_type(rec, modules)
                     self.write()
                     self.render_type(rec, modules)
 
@@ -296,8 +298,42 @@ class ModelGenerator(FilePrinter):
             self.write('# Properties:')
 
             for prop in spec['properties']:
-                if prop['name'] != 'id':
-                    self.render_prop(prop, mod, name, {})
+                self.render_prop(prop, mod, name, {})
+
+        self.dedent()
+
+    def render_base_type(self, spec, modules):
+        # assume nice names for now
+        mod, name = get_mod_and_name(spec['name'])
+        sql_name = get_sql_name(spec['name'])
+
+        self.write()
+        self.write(f'class {name}Base(sm.SQLModel):')
+        self.indent()
+
+        if spec['properties']:
+            self.write('# Properties:')
+
+            properties = sorted(spec['properties'], key=field_name_sort)
+            for prop in properties:
+                self.render_prop(prop, mod, name, modules)
+
+        single_links = [
+            link for link in spec['links']
+            if not link.get('has_link_object')
+               and link['cardinality'] == 'One'
+        ]
+        if single_links:
+            self.write()
+            self.write('# Links:')
+
+            links = sorted(spec['links'], key=field_name_sort)
+            for link in links:
+                self.render_link_col(link, mod, name, modules)
+
+        if not (spec['properties'] or single_links):
+            # Empty stub for a base type
+            self.write('pass')
 
         self.dedent()
 
@@ -307,7 +343,7 @@ class ModelGenerator(FilePrinter):
         sql_name = get_sql_name(spec['name'])
 
         self.write()
-        self.write(f'class {name}(sm.SQLModel, table=True):')
+        self.write(f'class {name}({name}Base, table=True):')
         self.indent()
         self.write(f'__tablename__ = {sql_name!r}')
         if mod != 'default':
@@ -337,15 +373,6 @@ class ModelGenerator(FilePrinter):
             f"sa_column=sa.Column('__type__', server_default='PLACEHOLDER'),")
         self.dedent()
         self.write(')')
-
-        if spec['properties']:
-            self.write()
-            self.write('# Properties:')
-
-            properties = sorted(spec['properties'], key=field_name_sort)
-            for prop in properties:
-                if prop['name'] != 'id':
-                    self.render_prop(prop, mod, name, modules)
 
         if spec['links']:
             self.write()
@@ -388,8 +415,10 @@ class ModelGenerator(FilePrinter):
 
         else:
             # plain property
+            opt = ' | None' if nullable else ''
             if sa_col:
-                self.write(f'{name}: {pytype} = sm.Field(sa_column=sa.Column(')
+                self.write(
+                    f'{name}: {pytype}{opt} = sm.Field(sa_column=sa.Column(')
                 self.indent()
                 self.write(f'{sa_col},')
                 self.write(f'nullable={nullable},')
@@ -397,8 +426,32 @@ class ModelGenerator(FilePrinter):
                 self.write(f'))')
             else:
                 self.write(
-                    f'{name}: {pytype} = sm.Field(nullable={nullable})'
+                    f'{name}: {pytype}{opt} = sm.Field(nullable={nullable})'
                 )
+
+    def render_link_col(self, spec, mod, parent, modules):
+        name = spec['name']
+        nullable = not spec['required']
+        tmod, target = get_mod_and_name(spec['target']['name'])
+        source = modules[mod]['object_types'][parent]
+        cardinality = spec['cardinality']
+
+        # If there's a link object there's no special column that needs to be
+        # created here.
+        if not spec.get('has_link_object'):
+            fk = self.get_fk(tmod, target, mod)
+            pyname = self.get_py_name(tmod, target, mod)
+
+            # cardinality 'Many' means there's an intermediate table referring
+            # to this object.
+            if cardinality == 'One':
+                opt = ' | None' if nullable else ''
+                self.write(f'{name}_id: uuid.UUID{opt} = sm.Field(')
+                self.indent()
+                self.write(f'{fk},')
+                self.write(f'nullable={nullable},')
+                self.dedent()
+                self.write(')')
 
     def render_link(self, spec, mod, parent, modules):
         name = spec['name']
@@ -418,18 +471,7 @@ class ModelGenerator(FilePrinter):
             pyname = self.get_py_name(tmod, target, mod)
 
             if cardinality == 'One':
-                self.write(
-                    f'{name}: {pyname} = '
-                    f"sm.Relationship(back_populates='source')"
-                )
-            elif cardinality == 'Many':
-                self.write(
-                    f'{name}: list[{pyname}] = '
-                    f"sm.Relationship(back_populates='source')"
-                )
-
-            if cardinality == 'One':
-                tmap = pyname
+                tmap = f'Optional[{pyname}]'
             elif cardinality == 'Many':
                 tmap = f'list[{pyname}]'
             # We want the cascade to delete orphans here as the intermediate
@@ -446,13 +488,8 @@ class ModelGenerator(FilePrinter):
             pyname = self.get_py_name(tmod, target, mod)
 
             if cardinality == 'One':
-                self.write(f'{name}_id: uuid.UUID = sm.Field(')
-                self.indent()
-                self.write(f'{fk},')
-                self.write(f'nullable={nullable},')
-                self.dedent()
-                self.write(')')
-
+                if nullable:
+                    pyname = f'Optional[{pyname}]'
                 self.write(f'{name}: {pyname} = sm.Relationship(')
                 self.indent()
                 self.write(f'back_populates={bklink!r},')
@@ -485,7 +522,7 @@ class ModelGenerator(FilePrinter):
             pyname = self.get_py_name(tmod, target, mod)
 
             if cardinality == 'One':
-                tmap = pyname
+                tmap = f'Optional[{pyname}]'
             elif cardinality == 'Many':
                 tmap = f'list[{pyname}]'
             # We want the cascade to delete orphans here as the intermediate
@@ -503,7 +540,7 @@ class ModelGenerator(FilePrinter):
                 # This is a backlink from a single link. There is no link table
                 # involved.
                 if cardinality == 'One':
-                    self.write(f'{name}: {pyname} = sm.Relationship(')
+                    self.write(f'{name}: Optional[{pyname}] = sm.Relationship(')
                     self.indent()
                     self.write(f"back_populates={bklink!r},")
                     self.dedent()

--- a/tests/test_sqlmodel_basic.py
+++ b/tests/test_sqlmodel_basic.py
@@ -333,6 +333,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         ).one()
 
         self.assertEqual(res.name, 'hello world')
+        self.assertEqual(res.vals, ['brown', 'fox'])
         self.assertEqual(res.bstr, b'word\x00\x0b')
         self.assertEqual(
             res.time,
@@ -632,7 +633,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         ).one()
 
         res.name = 'New Name'
-        # res.vals.append('jumped')
+        res.vals.append('jumped')
         res.bstr = b'\x01success\x02'
         res.time = dt.time(8, 23, 54, 999_000)
         res.date = dt.date(2020, 2, 14)
@@ -647,6 +648,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         ).one()
 
         self.assertEqual(upd.name, 'New Name')
+        self.assertEqual(upd.vals, ['brown', 'fox', 'jumped'])
         self.assertEqual(upd.bstr, b'\x01success\x02')
         self.assertEqual(
             upd.time,


### PR DESCRIPTION
Split all the models into a Base model (representing all user-properties and link columns for single links) and a full SQL table model derived from the Base with added relationships (for links and backlinks).

The Base model can be used to derive various interface models used in FastAPI. These are then used in customizing validation and rendering.