### PR TITLE
Exclude tests from wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -305,7 +305,7 @@ setuptools.setup(
     author_email='hello@magic.io',
     url='https://github.com/edgedb/edgedb-python',
     license='Apache License, Version 2.0',
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     provides=['edgedb', 'gel'],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
The `tests` folder should be included in the `sdist` only, not in wheels or installed into `site-packages/tests/*`.

Since edgedb-python 1.5.0, `tests` are installed as a global module by mistake, probably due to changes in setuptools 68.0.0 but I couldn't track down to the precise changes that affected our release.