### PR TITLE
Fix reused SSLContext ALPN bug

### DIFF
--- a/gel/ai/core.py
+++ b/gel/ai/core.py
@@ -58,7 +58,7 @@ class BaseRAGClient:
         self.context = types.QueryContext(**kwargs)
         args = dict(
             base_url=f"{proto}://{host}:{port}/branch/{branch}/ext/ai",
-            verify=params.ssl_ctx,
+            verify=params.make_ssl_ctx(),
         )
         if params.password is not None:
             args["auth"] = (params.user, params.password)


### PR DESCRIPTION
Cherr-picked from [#586](https://github.com/geldata/gel-python/pull/586/commits/9c007bef3ca8571c65e9c82abbdededa9217433f), fixes issues with mixing HTTP clients and binary protocol accesses.