### PR TITLE
Implement PreferRepeatableRead

### DIFF
--- a/gel/abstract.py
+++ b/gel/abstract.py
@@ -69,6 +69,7 @@ class QueryContext(typing.NamedTuple):
     state: typing.Optional[options.State]
     warning_handler: options.WarningHandler
     annotations: typing.Dict[str, str]
+    transaction_options: typing.Optional[options.TransactionOptions]
 
     def lower(
         self, *, allow_capabilities: enums.Capability
@@ -86,6 +87,7 @@ class QueryContext(typing.NamedTuple):
             allow_capabilities=allow_capabilities,
             state=self.state.as_dict() if self.state else None,
             annotations=self.annotations,
+            transaction_options=self.transaction_options,
         )
 
 
@@ -96,6 +98,7 @@ class ExecuteContext(typing.NamedTuple):
     state: typing.Optional[options.State]
     warning_handler: options.WarningHandler
     annotations: typing.Dict[str, str]
+    transaction_options: typing.Optional[options.TransactionOptions]
 
     def lower(
         self, *, allow_capabilities: enums.Capability
@@ -111,6 +114,7 @@ class ExecuteContext(typing.NamedTuple):
             allow_capabilities=allow_capabilities,
             state=self.state.as_dict() if self.state else None,
             annotations=self.annotations,
+            transaction_options=self.transaction_options,
         )
 
 
@@ -220,6 +224,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -233,6 +238,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -244,6 +250,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -255,6 +262,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -266,6 +274,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -277,6 +286,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -293,6 +303,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -307,6 +318,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             cache=self._get_query_cache(),
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -322,6 +334,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             cache=self._get_query_cache(),
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -349,6 +362,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -360,6 +374,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -376,6 +391,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -387,6 +403,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -398,6 +415,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -414,6 +432,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -430,6 +449,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -444,6 +464,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             cache=self._get_query_cache(),
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))
@@ -459,6 +480,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             cache=self._get_query_cache(),
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))

--- a/gel/base_client.py
+++ b/gel/base_client.py
@@ -701,10 +701,20 @@ class BaseClient(abstract.BaseReadOnlyExecutor, _options._OptionsMixin):
         )
 
     def _get_retry_options(self) -> typing.Optional[_options.RetryOptions]:
+        # This is overloaded in transaction.py to return None, to prevent
+        # retrying *inside* a transaction.
         return self._options.retry_options
 
+    def _get_active_tx_options(self) -> typing.Optional[
+        _options.TransactionOptions
+    ]:
+        # This is overloaded in transaction.py to return None, since
+        # the tx options are applied at the *start* of transactions,
+        # not inside them.
+        return self._options.transaction_options
+
     def _get_state(self) -> _options.State:
-        return self._options.state
+        return self._options.state.adjust_state(self._get_active_tx_options())
 
     def _get_warning_handler(self) -> _options.WarningHandler:
         return self._options.warning_handler

--- a/gel/base_client.py
+++ b/gel/base_client.py
@@ -714,7 +714,7 @@ class BaseClient(abstract.BaseReadOnlyExecutor, _options._OptionsMixin):
         return self._options.transaction_options
 
     def _get_state(self) -> _options.State:
-        return self._options.state.adjust_state(self._get_active_tx_options())
+        return self._options.state
 
     def _get_warning_handler(self) -> _options.WarningHandler:
         return self._options.warning_handler

--- a/gel/options.py
+++ b/gel/options.py
@@ -316,22 +316,6 @@ class State:
             rv["globals"] = self._globals
         return rv
 
-    def adjust_state(self, tx_options: TransactionOptions | None):
-        # TODO: cache this?
-        if tx_options and (
-            tx_options._isolation is not None
-            or tx_options._readonly is not None
-        ):
-            args = {}
-            if tx_options._isolation is not None:
-                args['default_transaction_isolation'] = tx_options._isolation
-            if tx_options._readonly is not None:
-                args['default_transaction_access_mode'] = (
-                    'ReadOnly' if tx_options._readonly else 'ReadWrite'
-                )
-            return self.with_config(args)
-        return self
-
 
 class _OptionsMixin:
     def __init__(self, *args, **kwargs):

--- a/gel/options.py
+++ b/gel/options.py
@@ -316,6 +316,22 @@ class State:
             rv["globals"] = self._globals
         return rv
 
+    def adjust_state(self, tx_options: TransactionOptions | None):
+        # TODO: cache this?
+        if tx_options and (
+            tx_options._isolation is not None
+            or tx_options._readonly is not None
+        ):
+            args = {}
+            if tx_options._isolation is not None:
+                args['default_transaction_isolation'] = tx_options._isolation
+            if tx_options._readonly is not None:
+                args['default_transaction_access_mode'] = (
+                    'ReadOnly' if tx_options._readonly else 'ReadWrite'
+                )
+            return self.with_config(args)
+        return self
+
 
 class _OptionsMixin:
     def __init__(self, *args, **kwargs):

--- a/gel/options.py
+++ b/gel/options.py
@@ -54,6 +54,7 @@ class IsolationLevel:
     """Isolation level for transaction"""
     Serializable = "Serializable"
     RepeatableRead = "RepeatableRead"
+    PreferRepeatableRead = "PreferRepeatableRead"
 
     @staticmethod
     def _to_start_tx_str(v):

--- a/gel/protocol/protocol.pxd
+++ b/gel/protocol/protocol.pxd
@@ -97,10 +97,12 @@ cdef class ExecuteContext:
         readonly BaseCodec out_dc
         readonly uint64_t capabilities
         readonly tuple warnings
+        readonly tuple unsafe_isolation_dangers
 
     cdef inline bint has_na_cardinality(self)
     cdef bint load_from_cache(self)
     cdef inline store_to_cache(self)
+    cdef prefers_repeatable_read(self)
 
 
 cdef class SansIOProtocol:
@@ -168,7 +170,7 @@ cdef class SansIOProtocol:
 
     cdef ensure_connected(self)
 
-    cdef WriteBuffer encode_parse_params(self, ExecuteContext ctx)
+    cdef WriteBuffer encode_parse_params(self, ExecuteContext ctx, dict state)
 
 
 include "protocol_v0.pxd"

--- a/gel/protocol/protocol.pxd
+++ b/gel/protocol/protocol.pxd
@@ -90,6 +90,7 @@ cdef class ExecuteContext:
         uint64_t allow_capabilities
         object state
         object annotations
+        object tx_options
 
         # Contextual variables
         readonly bytes cardinality
@@ -102,7 +103,6 @@ cdef class ExecuteContext:
     cdef inline bint has_na_cardinality(self)
     cdef bint load_from_cache(self)
     cdef inline store_to_cache(self)
-    cdef prefers_repeatable_read(self)
 
 
 cdef class SansIOProtocol:

--- a/gel/transaction.py
+++ b/gel/transaction.py
@@ -185,6 +185,14 @@ class BaseTransaction:
         return self._client._get_query_cache()
 
     def _get_retry_options(self) -> typing.Optional[options.RetryOptions]:
+        # Return None, to prevent retrying *inside* a transaction.
+        return None
+
+    def _get_active_tx_options(self) -> typing.Optional[
+        options.TransactionOptions
+    ]:
+        # Return None, since the tx options are applied at the *start*
+        # of transactions, not inside them.
         return None
 
     def _get_state(self) -> options.State:

--- a/gel/transaction.py
+++ b/gel/transaction.py
@@ -217,6 +217,7 @@ class BaseTransaction:
             query=abstract.QueryWithArgs(query, (), {}),
             cache=self._get_query_cache(),
             state=self._get_state(),
+            transaction_options=self._get_active_tx_options(),
             retry_options=self._get_retry_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1035,6 +1035,7 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
                 ),
                 retry_options=None,
                 state=None,
+                transaction_options=None,
                 warning_handler=lambda _ex, _: None,
                 annotations={},
             )

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -802,6 +802,7 @@ class TestSyncQuery(tb.SyncQueryTestCase):
                     ),
                     retry_options=None,
                     state=None,
+                    transaction_options=None,
                     warning_handler=lambda _ex, _: None,
                     annotations={},
                 )


### PR DESCRIPTION
COMMENTS NEEDED: We may want to reconsider the interface the user uses
to specify it!
Currently it works by setting default_transaction_isolation to the
enum value PreferRepeatableRead.

If that is set, the parse and execute paths will strip it from the
state that is sent, and then potentially inject RepeatableRead as the
value when doing execute, if it is safe.