### PR TITLE
Pin Django to ~5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 sqltest = [
     'SQLAlchemy>=2.0.0',
     'sqlmodel>=0.0.22',
-    'Django>=5.1.3',
+    'Django~=5.1.3',
     'psycopg2-binary>=2.9.10',
 ]
 doc = [


### PR DESCRIPTION
5.2 demands postgres 14, and we pretend to be postgres 13.