### PR TITLE
Make IsolationLevel enum values match the server names

### DIFF
--- a/gel/_testbase.py
+++ b/gel/_testbase.py
@@ -507,7 +507,10 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
                     self.client.execute(self.TEARDOWN_METHOD))
         finally:
             try:
-                if self.client.connection.is_in_transaction():
+                if (
+                    self.client.connection
+                    and self.client.connection.is_in_transaction()
+                ):
                     raise AssertionError(
                         'test connection is still in transaction '
                         '*after* the test')

--- a/gel/options.py
+++ b/gel/options.py
@@ -52,9 +52,19 @@ class RetryCondition:
 
 class IsolationLevel:
     """Isolation level for transaction"""
-    Serializable = "SERIALIZABLE"
-    RepeatableRead = "REPEATABLE READ"
+    Serializable = "Serializable"
+    RepeatableRead = "RepeatableRead"
 
+    @staticmethod
+    def _to_start_tx_str(v):
+        if v == IsolationLevel.Serializable:
+            return 'SERIALIZABLE'
+        elif v == IsolationLevel.RepeatableRead:
+            return 'REPEATABLE READ'
+        else:
+            raise ValueError(
+                f"Invalid isolation_level value for transaction(): {self}"
+            )
 
 class RetryOptions:
     """An immutable class that contains rules for `transaction()`"""
@@ -118,7 +128,7 @@ class TransactionOptions:
         return cls()
 
     def start_transaction_query(self):
-        isolation = str(self._isolation)
+        isolation = IsolationLevel._to_start_tx_str(self._isolation)
         if self._readonly:
             mode = 'READ ONLY'
         else:


### PR DESCRIPTION
This will let them be passed to the server.

Extracted out of #609