### PR TITLE
Make PreferRepeatableRead behave as Serializable for explicit transactions

### DIFF
--- a/gel/options.py
+++ b/gel/options.py
@@ -58,7 +58,13 @@ class IsolationLevel:
 
     @staticmethod
     def _to_start_tx_str(v):
-        if v == IsolationLevel.Serializable:
+        if (
+            v == IsolationLevel.Serializable
+            # We may *prefer* repeatable read, but we have not yet
+            # implemented it for explicit transactions. (Which will
+            # require some gnarly retry-and-caching logic.)
+            or v == IsolationLevel.PreferRepeatableRead
+        ):
             return 'SERIALIZABLE'
         elif v == IsolationLevel.RepeatableRead:
             return 'REPEATABLE READ'

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -65,6 +65,15 @@ class TestSyncTx(tb.SyncQueryTestCase):
             None,
             edgedb.IsolationLevel.Serializable,
         ]
+        if not (
+            str(self.server_version.stage) != 'dev'
+            and (self.server_version.major, self.server_version.minor) < (6, 5)
+        ):
+            isolations += [
+                edgedb.IsolationLevel.PreferRepeatableRead,
+                edgedb.IsolationLevel.RepeatableRead,
+            ]
+
         booleans = [None, True, False]
         all = itertools.product(isolations, booleans, booleans)
         for isolation, readonly, deferrable in all:


### PR DESCRIPTION
We will probably want to do better than this later, by trying
RepeatableRead and then falling back to Serializable in a retry if it
fails.