### PR TITLE
Support PreferRepeatableRead on explicit transactions by retrying

### DIFF
--- a/gel/protocol/lru.pxd
+++ b/gel/protocol/lru.pxd
@@ -25,4 +25,4 @@ cdef class LRUMapping:
         object _dict_move_to_end
         object _dict_get
 
-    cdef get(self, key, default)
+    cpdef get(self, key, default)

--- a/gel/protocol/lru.pyx
+++ b/gel/protocol/lru.pyx
@@ -53,7 +53,7 @@ cdef class LRUMapping:
         self._dict_get = self._dict.get
         self._maxsize = maxsize
 
-    cdef get(self, key, default):
+    cpdef get(self, key, default):
         o = self._dict_get(key, _LRU_MARKER)
         if o is _LRU_MARKER:
             return default

--- a/gel/transaction.py
+++ b/gel/transaction.py
@@ -86,7 +86,9 @@ class BaseTransaction:
             raise errors.InterfaceError(
                 'cannot start; the transaction is already started')
 
-        return self._options.start_transaction_query()
+        return self._options.start_transaction_query(
+            optimistic_isolation=self.__retry._optimistic_rr
+        )
 
     def _make_commit_query(self):
         self.__check_state('commit')
@@ -175,9 +177,17 @@ class BaseTransaction:
             await self._client._impl.release(self._connection)
 
         if (
-            extype is not None and
-            issubclass(extype, errors.EdgeDBError) and
-            ex.has_tag(errors.SHOULD_RETRY)
+            extype is not None
+            and issubclass(extype, errors.CapabilityError)
+            # XXX: This is not the best way to check this
+            and 'REPEATABLE READ' in str(ex)
+        ):
+            return self.__retry._retry_rr_failure(ex)
+
+        if (
+            extype is not None
+            and issubclass(extype, errors.EdgeDBError)
+            and ex.has_tag(errors.SHOULD_RETRY)
         ):
             return self.__retry._retry(ex)
 
@@ -233,6 +243,12 @@ class BaseRetry:
         self._next_backoff = 0
         self._options = owner._options
 
+        prefer_rr = (
+            self._options.transaction_options._isolation
+            == options.IsolationLevel.PreferRepeatableRead
+        )
+        self._optimistic_rr = prefer_rr
+
     def _retry(self, exc):
         self._last_exception = exc
         rule = self._options.retry_options.get_rule_for_exception(exc)
@@ -240,4 +256,14 @@ class BaseRetry:
             return False
         self._done = False
         self._next_backoff = rule.backoff(self._iteration)
+        return True
+
+    def _retry_rr_failure(self, exc):
+        # Retry a failure due to REPEATABLE READ not working
+        if not self._optimistic_rr:
+            return False
+        self._optimistic_rr = False
+        # Decrement _iteration count, since this one doesn't really count.
+        self._iteration -= 1
+        self._done = False
         return True


### PR DESCRIPTION
The method for detecting the need to retry is kind of hacky.

We cache using the filename and line number of the caller.