### PR TITLE
Add query batching API

### DIFF
--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -367,6 +367,7 @@ class AsyncIOBatchIteration(transaction.BaseTransaction):
         return self
 
     async def __aexit__(self, extype, ex, tb):
+        await self.wait()
         with self._exclusive():
             self._managed = False
             return await self._exit(extype, ex)

--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -349,55 +349,48 @@ class AsyncIORetry(transaction.BaseRetry):
         return iteration
 
 
-class AsyncIOBatch:
-    def __init__(
-        self, client: AsyncIOClient, optimistic_isolation: bool
-    ) -> None:
-        self._client = client
-        self._optimistic_isolation = optimistic_isolation
+class AsyncIOBatchIteration(transaction.BaseTransaction):
+
+    __slots__ = ("_managed", "_locked", "_batched_ops")
+
+    def __init__(self, retry, client, iteration):
+        super().__init__(retry, client, iteration)
+        self._managed = False
+        self._locked = False
         self._batched_ops = []
 
-    async def _privileged_execute(self, query: str) -> None:
-        await self._connection.privileged_execute(abstract.ExecuteContext(
-            query=abstract.QueryWithArgs(query, (), {}),
-            cache=self._client._get_query_cache(),
-            state=self._client._get_state(),
-            transaction_options=None,
-            retry_options=None,
-            warning_handler=self._client._get_warning_handler(),
-            annotations=self._client._get_annotations(),
-        ))
-
-    async def __aenter__(self) -> AsyncIOBatch:
-        conn = await self._client._impl.acquire()
-        self._connection = conn
-        try:
-            tx_options = self._client._options.transaction_options
-            query = tx_options.start_transaction_query(
-                optimistic_isolation=self._optimistic_isolation
-            )
-            if conn.is_closed():
-                await conn.connect()
-            await self._privileged_execute(query)
-        except BaseException:
-            try:
-                await self._privileged_execute("ROLLBACK;")
-                raise
-            finally:
-                self._connection = None
-                await self._client._impl.release(conn)
-
+    async def __aenter__(self):
+        if self._managed:
+            raise errors.InterfaceError(
+                'cannot enter context: already in an `async with` block')
+        self._managed = True
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, extype, ex, tb):
+        with self._exclusive():
+            self._managed = False
+            return await self._exit(extype, ex)
+
+    async def _ensure_transaction(self):
+        if not self._managed:
+            raise errors.InterfaceError(
+                "Only managed retriable transactions are supported. "
+                "Use `async with transaction:`"
+            )
+        await super()._ensure_transaction()
+
+    @contextlib.contextmanager
+    def _exclusive(self):
+        if self._locked:
+            raise errors.InterfaceError(
+                "concurrent queries within the same transaction "
+                "are not allowed"
+            )
+        self._locked = True
         try:
-            if exc_type is None:
-                await self._privileged_execute("COMMIT;")
-            else:
-                await self._privileged_execute("ROLLBACK;")
+            yield
         finally:
-            conn, self._connection = self._connection, None
-            await self._client._impl.release(conn)
+            self._locked = False
 
     async def send_query(self, query: str, *args, **kwargs) -> None:
         self._batched_ops.append(abstract.QueryContext(
@@ -449,8 +442,28 @@ class AsyncIOBatch:
         ))
 
     async def wait(self) -> list[Any]:
-        ops, self._batched_ops[:] = self._batched_ops[:], []
-        return await self._connection.batch_query(ops)
+        with self._exclusive():
+            await self._ensure_transaction()
+            ops, self._batched_ops[:] = self._batched_ops[:], []
+            return await self._connection.batch_query(ops)
+
+
+class AsyncIOBatch(transaction.BaseRetry):
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        # Note: when changing this code consider also
+        # updating Retry.__next__.
+        if self._done:
+            raise StopAsyncIteration
+        if self._next_backoff:
+            await asyncio.sleep(self._next_backoff)
+        self._done = True
+        iteration = AsyncIOBatchIteration(self, self._owner, self._iteration)
+        self._iteration += 1
+        return iteration
 
 
 class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
@@ -488,8 +501,8 @@ class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
     def transaction(self) -> AsyncIORetry:
         return AsyncIORetry(self)
 
-    def _batch(self, *, optimistic_isolation: bool) -> AsyncIOBatch:
-        return AsyncIOBatch(self, optimistic_isolation)
+    def _batch(self) -> AsyncIOBatch:
+        return AsyncIOBatch(self)
 
     async def __aenter__(self):
         return await self.ensure_connected()

--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -488,6 +488,9 @@ class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
     def transaction(self) -> AsyncIORetry:
         return AsyncIORetry(self)
 
+    def _batch(self, *, optimistic_isolation: bool) -> AsyncIOBatch:
+        return AsyncIOBatch(self, optimistic_isolation)
+
     async def __aenter__(self):
         return await self.ensure_connected()
 

--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -456,7 +456,7 @@ class AsyncIOBatch(transaction.BaseRetry):
 
     async def __anext__(self):
         # Note: when changing this code consider also
-        # updating Retry.__next__.
+        # updating Batch.__next__.
         if self._done:
             raise StopAsyncIteration
         if self._next_backoff:

--- a/gel/base_client.py
+++ b/gel/base_client.py
@@ -279,7 +279,11 @@ class BaseConnection(metaclass=abc.ABCMeta):
         ],
     ) -> list[typing.Any]:
         ctxs = [
-            ctx.lower(allow_capabilities=enums.Capability.EXECUTE)
+            ctx.lower(
+                allow_capabilities=(
+                    enums.Capability.EXECUTE & ~enums.Capability.DDL
+                )
+            )
             for ctx in ops
         ]
         rv = await self._protocol.batch_execute(ctxs)

--- a/gel/base_client.py
+++ b/gel/base_client.py
@@ -272,6 +272,22 @@ class BaseConnection(metaclass=abc.ABCMeta):
                 _inner, execute_context.retry_options, ctx
             )
 
+    async def batch_query(
+        self,
+        ops: list[
+            typing.Union[abstract.QueryContext, abstract.ExecuteContext]
+        ],
+    ) -> list[typing.Any]:
+        ctxs = [
+            ctx.lower(allow_capabilities=enums.Capability.EXECUTE)
+            for ctx in ops
+        ]
+        rv = await self._protocol.batch_execute(ctxs)
+        return [
+            op.warning_handler(ctx.warnings, res) if ctx.warnings else res
+            for op, ctx, res in zip(ops, ctxs, rv)
+        ]
+
     async def describe(
         self, describe_context: abstract.DescribeContext
     ) -> abstract.DescribeResult:

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+from typing import Any
+
 import contextlib
 import datetime
 import queue
@@ -377,6 +380,126 @@ class Retry(transaction.BaseRetry):
         return iteration
 
 
+class BatchIteration(transaction.BaseTransaction):
+
+    __slots__ = ("_managed", "_lock", "_batched_ops")
+
+    def __init__(self, retry, client, iteration):
+        super().__init__(retry, client, iteration)
+        self._managed = False
+        self._lock = threading.Lock()
+        self._batched_ops = []
+
+    def __enter__(self):
+        with self._exclusive():
+            if self._managed:
+                raise errors.InterfaceError(
+                    'cannot enter context: already in a `with` block')
+            self._managed = True
+            return self
+
+    def __exit__(self, extype, ex, tb):
+        with self._exclusive():
+            self._client._iter_coroutine(self._wait())
+            self._managed = False
+            return self._client._iter_coroutine(self._exit(extype, ex))
+
+    async def _ensure_transaction(self):
+        if not self._managed:
+            raise errors.InterfaceError(
+                "Only managed retriable transactions are supported. "
+                "Use `with transaction:`"
+            )
+        await super()._ensure_transaction()
+
+    @contextlib.contextmanager
+    def _exclusive(self):
+        if not self._lock.acquire(blocking=False):
+            raise errors.InterfaceError(
+                "concurrent queries within the same transaction "
+                "are not allowed"
+            )
+        try:
+            yield
+        finally:
+            self._lock.release()
+
+    def send_query(self, query: str, *args, **kwargs) -> None:
+        self._batched_ops.append(abstract.QueryContext(
+            query=abstract.QueryWithArgs(query, args, kwargs),
+            cache=self._client._get_query_cache(),
+            query_options=abstract._query_opts,
+            retry_options=None,
+            state=self._client._get_state(),
+            transaction_options=None,
+            warning_handler=self._client._get_warning_handler(),
+            annotations=self._client._get_annotations(),
+        ))
+
+    def send_query_single(self, query: str, *args, **kwargs) -> None:
+        self._batched_ops.append(abstract.QueryContext(
+            query=abstract.QueryWithArgs(query, args, kwargs),
+            cache=self._client._get_query_cache(),
+            query_options=abstract._query_single_opts,
+            retry_options=None,
+            state=self._client._get_state(),
+            transaction_options=None,
+            warning_handler=self._client._get_warning_handler(),
+            annotations=self._client._get_annotations(),
+        ))
+
+    def send_query_required_single(
+        self, query: str, *args, **kwargs
+    ) -> None:
+        self._batched_ops.append(abstract.QueryContext(
+            query=abstract.QueryWithArgs(query, args, kwargs),
+            cache=self._client._get_query_cache(),
+            query_options=abstract._query_required_single_opts,
+            retry_options=None,
+            state=self._client._get_state(),
+            transaction_options=None,
+            warning_handler=self._client._get_warning_handler(),
+            annotations=self._client._get_annotations(),
+        ))
+
+    def send_execute(self, commands: str, *args, **kwargs) -> None:
+        self._batched_ops.append(abstract.ExecuteContext(
+            query=abstract.QueryWithArgs(commands, args, kwargs),
+            cache=self._client._get_query_cache(),
+            retry_options=None,
+            state=self._client._get_state(),
+            transaction_options=None,
+            warning_handler=self._client._get_warning_handler(),
+            annotations=self._client._get_annotations(),
+        ))
+
+    def wait(self) -> list[Any]:
+        with self._exclusive():
+            return self._client._iter_coroutine(self._wait())
+
+    async def _wait(self) -> list[Any]:
+        await self._ensure_transaction()
+        ops, self._batched_ops[:] = self._batched_ops[:], []
+        return await self._connection.batch_query(ops)
+
+
+class Batch(transaction.BaseRetry):
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Note: when changing this code consider also
+        # updating AsyncIOBatch.__anext__.
+        if self._done:
+            raise StopIteration
+        if self._next_backoff:
+            time.sleep(self._next_backoff)
+        self._done = True
+        iteration = BatchIteration(self, self._owner, self._iteration)
+        self._iteration += 1
+        return iteration
+
+
 class Client(base_client.BaseClient, abstract.Executor):
     """A lazy connection pool.
 
@@ -412,6 +535,9 @@ class Client(base_client.BaseClient, abstract.Executor):
 
     def transaction(self) -> Retry:
         return Retry(self)
+
+    def _batch(self) -> Batch:
+        return Batch(self)
 
     def close(self, timeout=None):
         """Attempt to gracefully close all connections in the client.

--- a/gel/protocol/asyncio_proto.pxd
+++ b/gel/protocol/asyncio_proto.pxd
@@ -32,3 +32,4 @@ cdef class AsyncIOProtocol(protocol.SansIOProtocolBackwardsCompatible):
 
         object loop
         object msg_waiter
+        object writable

--- a/gel/protocol/protocol.pxd
+++ b/gel/protocol/protocol.pxd
@@ -103,6 +103,7 @@ cdef class ExecuteContext:
     cdef inline bint has_na_cardinality(self)
     cdef bint load_from_cache(self)
     cdef inline store_to_cache(self)
+    cdef inline invalidate_cache(self)
 
 
 cdef class SansIOProtocol:

--- a/gel/protocol/protocol.pxd
+++ b/gel/protocol/protocol.pxd
@@ -171,6 +171,7 @@ cdef class SansIOProtocol:
     cdef ensure_connected(self)
 
     cdef WriteBuffer encode_parse_params(self, ExecuteContext ctx, dict state)
+    cdef _handle_query_result(self, ExecuteContext ctx, ret)
 
 
 include "protocol_v0.pxd"

--- a/gel/protocol/protocol.pyx
+++ b/gel/protocol/protocol.pyx
@@ -734,7 +734,7 @@ cdef class SansIOProtocol:
                     self.fallthrough()
 
             finally:
-                self.buffer.discard_message()
+                self.buffer.finish_message()
 
         if exc is not None:
             raise exc
@@ -819,6 +819,8 @@ cdef class SansIOProtocol:
                     return ret
 
     async def batch_execute(self, ctxs: list[ExecuteContext]):
+        cdef ExecuteContext ctx
+
         self.ensure_connected()
         self.reset_status()
 

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -49,9 +49,13 @@ class TestSyncQuery(tb.SyncQueryTestCase):
         CREATE SCALAR TYPE MyEnum EXTENDING enum<"A", "B">;
 
         CREATE SCALAR TYPE test::MyType EXTENDING int32;
+        CREATE SCALAR TYPE test::MyType2 EXTENDING int64;
+        CREATE SCALAR TYPE test::MyType3 EXTENDING int16;
     '''
 
     TEARDOWN = '''
+        DROP SCALAR TYPE test::MyType3;
+        DROP SCALAR TYPE test::MyType2;
         DROP SCALAR TYPE test::MyType;
         DROP TYPE test::Tmp;
         DROP TYPE test::TmpConflictChild;
@@ -1039,3 +1043,122 @@ class TestSyncQuery(tb.SyncQueryTestCase):
         # At last, verify that a string gets encoded properly
         val = self.client.query_single("SELECT <test::MyType>$0", "foo")
         self.assertEqual(val, 'foo')
+
+    def test_batch_01(self):
+        for bx in self.client._batch():
+            with bx:
+                bx.send_query_single('SELECT 1')
+                bx.send_query_single('SELECT 2')
+                bx.send_query_single('SELECT 3')
+
+                self.assertEqual(bx.wait(), [1, 2, 3])
+
+                bx.send_query_single('SELECT 4')
+                bx.send_query_single('SELECT 5')
+                bx.send_query_single('SELECT 6')
+
+                self.assertEqual(bx.wait(), [4, 5, 6])
+
+    def test_batch_02(self):
+        for bx in self.client._batch():
+            with bx:
+                bx.send_query_required_single('''
+                    INSERT test::Tmp {
+                        tmp := 'Test Batch'
+                    };
+                ''')
+                bx.send_query('''
+                    SELECT
+                        test::Tmp
+                    FILTER
+                        .tmp = 'Test Batch';
+                ''')
+                inserted, selected = bx.wait()
+
+        self.assertEqual([inserted.id], [o.id for o in selected])
+
+    def test_batch_03(self):
+        for bx in self.client._batch():
+            with bx:
+                bx.send_execute('''
+                    INSERT test::Tmp {
+                        tmp := 'Test Auto Wait'
+                    };
+                ''')
+                # No explicit wait() - should auto-wait on scope exit
+
+        rv = self.client.query('''
+            SELECT
+                test::Tmp
+            FILTER
+                .tmp = 'Test Auto Wait';
+        ''')
+        self.assertEqual(len(rv), 1)
+
+    def test_batch_04(self):
+        with self.assertRaises(edgedb.TransactionError):
+            for bx in self.client._batch():
+                with bx:
+                    bx.send_execute('''
+                        INSERT test::Tmp {
+                            tmp := 'Test Atomic'
+                        };
+                    ''')
+                    bx.send_query_single('SELECT 1/0')
+                    bx.send_execute('''
+                        INSERT test::Tmp {
+                            tmp := 'Test Atomic'
+                        };
+                    ''')
+
+                    with self.assertRaises(edgedb.DivisionByZeroError):
+                        bx.wait()
+
+        rv = self.client.query('''
+            SELECT
+                test::Tmp
+            FILTER
+                .tmp = 'Test Atomic';
+        ''')
+        self.assertEqual(len(rv), 0)
+
+    def test_batch_05(self):
+        for bx in self.client._batch():
+            with bx:
+                # Test alternating queries that need Parse
+                bx.send_query_single('SELECT 1')
+                bx.send_query_single('SELECT <int16>$0', 2)
+                bx.send_query_single('SELECT 3')
+                bx.send_query_single('SELECT <int32>$0', 4)
+                bx.send_query_single('SELECT 5')
+                bx.send_query_single('SELECT <int64>$0', 6)
+                bx.send_query_single('SELECT 7')
+                self.assertEqual(bx.wait(), [1, 2, 3, 4, 5, 6, 7])
+
+    def test_batch_06(self):
+        # Cache the input type descriptors first
+        val = self.client.query_single("SELECT <test::MyType>$0", 42)
+        self.assertEqual(val, 42)
+        val = self.client.query_single("SELECT <test::MyType2>$0", 42)
+        self.assertEqual(val, 42)
+        val = self.client.query_single("SELECT <test::MyType3>$0", 42)
+        self.assertEqual(val, 42)
+
+        # Modify the schema to outdate the previous type descriptors
+        self.client.execute("""
+            DROP SCALAR TYPE test::MyType;
+            DROP SCALAR TYPE test::MyType2;
+            DROP SCALAR TYPE test::MyType3;
+            CREATE SCALAR TYPE test::MyType EXTENDING std::int64;
+            CREATE SCALAR TYPE test::MyType2 EXTENDING std::int16;
+            CREATE SCALAR TYPE test::MyType3 EXTENDING std::int32;
+        """)
+
+        # We should retry only once and succeed here
+        c = self.client.with_retry_options(edgedb.RetryOptions(attempts=2))
+        for bx in c._batch():
+            with bx:
+                bx.send_query_single('SELECT <test::MyType>$0', 42)
+                bx.send_query_single('SELECT <test::MyType2>$0', 42)
+                bx.send_query_single('SELECT <test::MyType3>$0', 42)
+                self.assertEqual(bx.wait(), [42, 42, 42])


### PR DESCRIPTION
```python
import asyncio
import gel

client = gel.create_async_client()

async def main():
    async for b in client._batch():
        async with b:
            await b.send_query_single("select 42 + <int32>$0", 2)
            await b.send_query_single("select 42 * <float32>$0", 2)
            x, y = await b.wait()
            assert x == 44
            assert y == 84.0
            print(x, y)

asyncio.run(main())
```

For manual transaction isolation, use `client.with_transaction_options()`.

- [x] Test and fix
- [ ] Send messages immediately in `send_query_*()`
- [x] Add test
- [x] Add backpressure
- [x] Add retrying transaction
- [x] Add blocking API
- [x] Retry on compatible new codecs without cache