### PR TITLE
Retry on input type mismatches if compatible

### DIFF
--- a/gel/protocol/protocol.pyx
+++ b/gel/protocol/protocol.pyx
@@ -521,6 +521,13 @@ cdef class SansIOProtocol:
                                 )
                             except errors.QueryArgumentError as ex:
                                 exc = ex
+                            else:
+                                # Now we know for sure that the new codec can
+                                # encode the same arguments, let's hint the
+                                # caller to retry as a special case.
+                                exc.tags = exc.tags.union(
+                                    {errors.SHOULD_RETRY}
+                                )
                             finally:
                                 buf = None
                     else:

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -47,9 +47,12 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
         };
 
         CREATE SCALAR TYPE MyEnum EXTENDING enum<"A", "B">;
+
+        CREATE SCALAR TYPE test::MyType EXTENDING int32;
     '''
 
     TEARDOWN = '''
+        DROP SCALAR TYPE test::MyType;
         DROP TYPE test::Tmp;
     '''
 
@@ -1165,3 +1168,47 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
 
         res = await self.client.query_sql("SELECT FROM generate_series(0, 1)")
         self.assertEqual(res[0].as_dict(), {})
+
+    async def test_retry_mismatch_input_typedesc(self):
+        # Cache the input type descriptor first
+        val = await self.client.query_single("SELECT <test::MyType>$0", 42)
+        self.assertEqual(val, 42)
+
+        # Modify the schema to outdate the previous type descriptor
+        await self.client.execute("""
+            DROP SCALAR TYPE test::MyType;
+            CREATE SCALAR TYPE test::MyType EXTENDING std::int64;
+        """)
+
+        # Run again with the outdated type descriptor. The server shall send a
+        # ParameterTypeMismatchError following a CommandDataDescription message
+        # with an updated type descriptor. Because we can re-encode `42` as
+        # `int64`, the client should just retry and work fine.
+        val = await self.client.query_single("SELECT <test::MyType>$0", 42)
+        self.assertEqual(val, 42)
+
+        # Modify the schema again to an incompatible type
+        await self.client.execute("""
+            DROP SCALAR TYPE test::MyType;
+            CREATE SCALAR TYPE test::MyType EXTENDING std::str;
+        """)
+
+        # The cached codec doesn't know about the change, so the client cannot
+        # encode this string yet:
+        with self.assertRaisesRegex(
+            edgedb.InvalidArgumentError, 'expected an int'
+        ):
+            await self.client.query_single("SELECT <test::MyType>$0", "foo")
+
+        # Try `42` again. The cached codec encodes properly, but the server
+        # sends a ParameterTypeMismatchError due to mismatching input type, and
+        # we shall receive the new string codec. Because we cannot re-encode
+        # `42` as str, the client shouldn't retry but raise a translated error.
+        with self.assertRaisesRegex(
+            edgedb.QueryArgumentError, 'expected str, got int'
+        ):
+            await self.client.query_single("SELECT <test::MyType>$0", 42)
+
+        # At last, verify that a string gets encoded properly
+        val = await self.client.query_single("SELECT <test::MyType>$0", "foo")
+        self.assertEqual(val, 'foo')


### PR DESCRIPTION
If the cached codec mismatches the server schema, we shall allow retrying if the new codec encodes the user arguments successfully.