### PR TITLE
Allow specifying `allow_user_specified_id` for codegen

### DIFF
--- a/gel/codegen/cli.py
+++ b/gel/codegen/cli.py
@@ -77,7 +77,6 @@ parser.add_argument(
 parser.add_argument(
     "--allow-user-specified-id",
     action=argparse.BooleanOptionalAction,
-    default=argparse.SUPPRESS,  # override the builtin help for default
     help="Allow user specified ids in .edgeql files (default is to disallow).",
 )
 

--- a/gel/codegen/cli.py
+++ b/gel/codegen/cli.py
@@ -28,8 +28,7 @@ class ColoredArgumentParser(argparse.ArgumentParser):
         c = generator.C
         self.exit(
             2,
-            f"{c.BOLD}{c.FAIL}error:{c.ENDC} "
-            f"{c.BOLD}{message:s}{c.ENDC}\n",
+            f"{c.BOLD}{c.FAIL}error:{c.ENDC} {c.BOLD}{message:s}{c.ENDC}\n",
         )
 
 
@@ -66,7 +65,7 @@ parser.add_argument(
     choices=["blocking", "async"],
     nargs="*",
     default=["async"],
-    help="Choose one or more targets to generate code (default is async)."
+    help="Choose one or more targets to generate code (default is async).",
 )
 parser.add_argument(
     "--skip-pydantic-validation",
@@ -74,6 +73,12 @@ parser.add_argument(
     default=argparse.SUPPRESS,  # override the builtin help for default
     help="Add a mixin to generated dataclasses "
     "to skip Pydantic validation (default is to add the mixin).",
+)
+parser.add_argument(
+    "--allow-user-specified-id",
+    action=argparse.BooleanOptionalAction,
+    default=argparse.SUPPRESS,  # override the builtin help for default
+    help="Allow user specified ids in .edgeql files (default is to disallow).",
 )
 
 

--- a/gel/codegen/generator.py
+++ b/gel/codegen/generator.py
@@ -287,7 +287,9 @@ class Generator:
             with target.open("w") as f:
                 f.write(buf.getvalue())
 
-    def _write_comments(self, f: io.TextIOBase, src: typing.List[pathlib.Path]):
+    def _write_comments(
+        self, f: io.TextIOBase, src: typing.List[pathlib.Path]
+    ):
         src_str = map(
             lambda p: repr(p.relative_to(self._project_dir).as_posix()), src
         )
@@ -399,7 +401,9 @@ class Generator:
             print(f"{INDENT}{rt}executor.{method}(", file=buf)
         print(f'{INDENT}{INDENT}"""\\', file=buf)
         print(
-            textwrap.indent(textwrap.dedent(query).strip(), f"{INDENT}{INDENT}")
+            textwrap.indent(
+                textwrap.dedent(query).strip(), f"{INDENT}{INDENT}"
+            )
             + "\\",
             file=buf,
         )


### PR DESCRIPTION
## Reason
When a user really really wants to specify the `id` field in their queries, this is possible with the `allow_user_specified_id` parameter. 
However, when generating the code, this is not possible to specify, which causes the CLI codegen to fail:
```
gel.errors.QueryError: cannot assign to property 'id'
   ┌─ query:5:7
   │ 
 5 │         id := <uuid>$entity_id
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider enabling the "allow_user_specified_id" configuration parameter to allow setting custom object
```
Since edge cases exist where it might be beneficial to specify `id` in queries I added a `--allow-user-specified-id` parameter to the CLI which sets this option on the client used for the query codegen.

## Testing
To test this I quickly replaced my `gel` dependency with my fork, it works as expected. If required please let me know how you would like an additional unit test for this to look like.