### PR TITLE
models: Re-export contents of `default` module in root and lazy-import submodules

### DIFF
--- a/gel/_internal/_codegen/_module.py
+++ b/gel/_internal/_codegen/_module.py
@@ -332,6 +332,10 @@ class GeneratedModule:
     def export(self, *names: str) -> None:
         self._exports.update(names)
 
+    @property
+    def exports(self) -> set[str]:
+        return self._exports
+
     def current_indentation(self) -> str:
         return self.INDENT * self._indent_level
 

--- a/tests/dbsetup/orm.gel
+++ b/tests/dbsetup/orm.gel
@@ -39,3 +39,17 @@ type AssortedScalars {
     lts: cal::local_datetime;
     bstr: bytes;
 }
+
+module sub {
+    type TypeInSub {
+        post: default::Post;
+        subsub: default::sub::subsub::TypeInSubSub;
+    }
+
+    module subsub {
+        type TypeInSubSub;
+    }
+}
+
+module emptysub {
+}

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -351,6 +351,18 @@ class TestModelGenerator(tb.ModelTestCase):
             self.client.query(q)
 
     @tb.typecheck
+    def test_modelgen_submodules_and_reexports(self):
+        import models
+
+        models.default.Post
+        models.std.str
+
+        self.assertEqual(
+            reveal_type(models.sub.TypeInSub.post),
+            "type[models.default.Post]",
+        )
+
+    @tb.typecheck
     def test_modelgen_data_model_validation_1(self):
         from typing import cast
         from gel._internal._dlist import DistinctList


### PR DESCRIPTION
The generated models package now re-exports the contents of `default` in
`__init__.py`, so `import models; models.Foo` works.  Additionally, each
module lazy-imports its direct submodules, so explicit imports are not
needed (`models.std.math.abs()` just works).

Closes: #639
