### PR TITLE
Rename `gel-generate` to `gel-generate-py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ issues = "https://github.com/geldata/gel-python/issues"
 [project.scripts]
 edgedb-py = "gel.codegen.cli:main"
 gel-py = "gel.codegen.cli:main"
-gel-generate = "gel.codegen.cli:generate"
+gel-generate-py = "gel.codegen.cli:generate"
 gel-orm = "gel.orm.cli:main"
 gel = "gel.cli:main"
 


### PR DESCRIPTION
The latter is the convention expected by `gel generate`.
