### PR TITLE
models: Expose pointer reflection in `__gel_reflection__`

### DIFF
--- a/gel/_internal/_edgeql/_tokens.py
+++ b/gel/_internal/_edgeql/_tokens.py
@@ -262,6 +262,7 @@ class Operation(enum.Enum):
     PARENEXPR = enum.auto()
     PATH = enum.auto()
     CALL = enum.auto()
+    RAW = enum.auto()
 
 
 class Precedence(NamedTuple):
@@ -344,6 +345,7 @@ PRECEDENCE: dict[Token | tuple[Token, int] | Operation, Precedence] = {
     Token.OPTIONAL: Precedence(28, Assoc.RIGHT),
     Token.MULTI: Precedence(28, Assoc.RIGHT),
     Token.SINGLE: Precedence(28, Assoc.RIGHT),
+    Operation.RAW: Precedence(100, Assoc.NONASSOC),
 }
 
 

--- a/gel/_internal/_qb/__init__.py
+++ b/gel/_internal/_qb/__init__.py
@@ -20,6 +20,7 @@ from ._expressions import (
     BinaryOp,
     BoolLiteral,
     BytesLiteral,
+    CastOp,
     DecimalLiteral,
     DeleteStmt,
     Direction,
@@ -52,6 +53,7 @@ from ._expressions import (
     StringLiteral,
     UpdateStmt,
     Variable,
+    get_object_type_splat,
     toplevel_edgeql,
 )
 
@@ -75,6 +77,11 @@ from ._protocols import (
     is_expr_compatible,
 )
 
+from ._reflection import (
+    GelPointerReflection,
+    GelTypeMetadata,
+)
+
 
 __all__ = (
     "AbstractDescriptor",
@@ -86,6 +93,7 @@ __all__ = (
     "BinaryOp",
     "BoolLiteral",
     "BytesLiteral",
+    "CastOp",
     "DecimalLiteral",
     "DeleteStmt",
     "Direction",
@@ -99,6 +107,8 @@ __all__ = (
     "FloatLiteral",
     "ForStmt",
     "FuncCall",
+    "GelPointerReflection",
+    "GelTypeMetadata",
     "IndexOp",
     "InfixOp",
     "IntLiteral",
@@ -132,6 +142,7 @@ __all__ = (
     "edgeql",
     "edgeql_qb_expr",
     "exprmethod",
+    "get_object_type_splat",
     "is_expr_compatible",
     "toplevel_edgeql",
 )

--- a/gel/_internal/_qb/_abstract.py
+++ b/gel/_internal/_qb/_abstract.py
@@ -96,6 +96,21 @@ class TypedExpr(Expr):
         return self.type_
 
 
+@dataclass(kw_only=True, frozen=True)
+class QueryText(TypedExpr):
+    text: str
+
+    @property
+    def precedence(self) -> _edgeql.Precedence:
+        return _edgeql.PRECEDENCE[_edgeql.Operation.RAW]
+
+    def subnodes(self) -> Iterable[Node | None]:
+        return ()
+
+    def __edgeql_expr__(self, *, ctx: ScopeContext | None) -> str:
+        return self.text
+
+
 class AtomicExpr(TypedExpr):
     pass
 

--- a/gel/_internal/_qb/_expressions.py
+++ b/gel/_internal/_qb/_expressions.py
@@ -14,6 +14,8 @@ from typing_extensions import Self
 import itertools
 import textwrap
 import typing
+import weakref
+
 from dataclasses import dataclass, field
 
 from gel._internal import _edgeql
@@ -34,11 +36,17 @@ from ._abstract import (
     Symbol,
     TypedExpr,
 )
-from ._protocols import ExprCompatible, edgeql, edgeql_qb_expr
+from ._protocols import (
+    ExprCompatible,
+    edgeql,
+    edgeql_qb_expr,
+)
 
 if TYPE_CHECKING:
     import decimal
     from collections.abc import Callable, Iterable
+
+    from ._reflection import GelTypeMetadata
 
 
 class ExprPlaceholder(Expr):
@@ -254,6 +262,31 @@ class PrefixOp(Op):
         if _need_right_parens(self.precedence, self.expr):
             left = f"({left})"
         return f"{self.op} {left}"
+
+
+@dataclass(kw_only=True, frozen=True)
+class CastOp(PrefixOp):
+    def __init__(
+        self,
+        *,
+        expr: ExprCompatible,
+        type_: SchemaPath,
+    ) -> None:
+        op = _edgeql.Token.RANGBRACKET
+        super().__init__(expr=expr, op=op, type_=type_)
+
+    @property
+    def precedence(self) -> _edgeql.Precedence:
+        return _edgeql.PRECEDENCE[_edgeql.Operation.RAW]
+
+    def subnodes(self) -> Iterable[Node]:
+        return (self.expr,)
+
+    def __edgeql_expr__(self, *, ctx: ScopeContext | None) -> str:
+        expr = edgeql(self.expr, ctx=ctx)
+        if _need_right_parens(self.precedence, self.expr):
+            expr = f"({expr})"
+        return f"<{self.type.as_quoted_schema_name()}>{expr}"
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -566,6 +599,7 @@ class SelectStmt(IteratorStmt):
         expr: Expr,
         *,
         new_stmt_if: Callable[[SelectStmt], bool] | None = None,
+        splat_cb: Callable[[], Shape] | None = None,
     ) -> SelectStmt:
         if not isinstance(expr, SelectStmt) or (
             new_stmt_if is not None and new_stmt_if(expr)
@@ -574,10 +608,11 @@ class SelectStmt(IteratorStmt):
             if isinstance(expr, ShapeOp):
                 kwargs["body_scope"] = expr.scope
             elif isinstance(expr, SchemaSet):
-                expr = ShapeOp(
-                    iter_expr=expr,
-                    shape=Shape.splat(source=expr.type),
-                )
+                if splat_cb is not None:
+                    shape = splat_cb()
+                else:
+                    shape = Shape.splat(source=expr.type)
+                expr = ShapeOp(iter_expr=expr, shape=shape)
                 kwargs["body_scope"] = expr.scope
             expr = SelectStmt(iter_expr=expr, **kwargs)  # type: ignore [arg-type]
 
@@ -703,6 +738,7 @@ class ShapeElement(Node):
     def splat(
         cls,
         source: _reflection.SchemaPath,
+        *,
         kind: Splat = Splat.STAR,
     ) -> Self:
         return cls(name=kind, origin=source)
@@ -719,9 +755,11 @@ class Shape(Node):
     def splat(
         cls,
         source: _reflection.SchemaPath,
+        *,
         kind: Splat = Splat.STAR,
     ) -> Self:
-        return cls(elements=[ShapeElement.splat(source=source, kind=kind)])
+        elements = [ShapeElement.splat(source=source, kind=kind)]
+        return cls(elements=elements)
 
 
 def _render_shape(
@@ -813,8 +851,26 @@ def _need_right_parens(
     return _edgeql.need_right_parens(prod_prec, right_prec)
 
 
-def toplevel_edgeql(x: ExprCompatible) -> str:
+_type_splat_cache: weakref.WeakKeyDictionary[type[GelTypeMetadata], Shape] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def get_object_type_splat(cls: type[GelTypeMetadata]) -> Shape:
+    shape = _type_splat_cache.get(cls)
+    if shape is None:
+        reflection = cls.__gel_reflection__
+        shape = Shape.splat(source=reflection.name)
+        _type_splat_cache[cls] = shape
+    return shape
+
+
+def toplevel_edgeql(
+    x: ExprCompatible,
+    *,
+    splat_cb: Callable[[], Shape] | None = None,
+) -> str:
     expr = edgeql_qb_expr(x)
     if not isinstance(expr, Stmt):
-        expr = SelectStmt.wrap(expr)
+        expr = SelectStmt.wrap(expr, splat_cb=splat_cb)
     return edgeql(expr, ctx=None)

--- a/gel/_internal/_qb/_generics.py
+++ b/gel/_internal/_qb/_generics.py
@@ -22,13 +22,20 @@ from gel._internal import _typing_inspect
 from gel._internal import _utils
 
 from ._abstract import AbstractFieldDescriptor
-from ._expressions import BinaryOp, Path, Variable, toplevel_edgeql
+from ._expressions import (
+    BinaryOp,
+    Path,
+    Variable,
+    get_object_type_splat,
+    toplevel_edgeql,
+)
 from ._protocols import (
     TypeClassProto,
     assert_edgeql_qb_expr,
     edgeql_qb_expr,
     is_exprmethod,
 )
+from ._reflection import GelTypeMetadata
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -232,7 +239,12 @@ class BaseAlias(metaclass=BaseAliasMeta):
         return expr
 
     def __edgeql__(self) -> tuple[type, str]:
-        return self.__gel_origin__, toplevel_edgeql(self)
+        type_ = self.__gel_origin__
+        if issubclass(type_, GelTypeMetadata):
+            splat_cb = functools.partial(get_object_type_splat, type_)
+        else:
+            splat_cb = None
+        return type_, toplevel_edgeql(self, splat_cb=splat_cb)
 
 
 class PathAlias(BaseAlias):

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -1,0 +1,30 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, ClassVar
+
+import dataclasses
+
+if TYPE_CHECKING:
+    import uuid
+    from gel._internal import _edgeql
+    from gel._internal import _reflection
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class GelPointerReflection:
+    type_: _reflection.SchemaPath
+    kind: _edgeql.PointerKind
+    cardinality: _edgeql.Cardinality
+    computed: bool
+    readonly: bool
+    properties: tuple[GelPointerReflection, ...] | None
+
+
+class GelTypeMetadata:
+    class __gel_reflection__:  # noqa: N801
+        id: ClassVar[uuid.UUID]
+        name: ClassVar[_reflection.SchemaPath]
+        pointers: ClassVar[dict[str, GelPointerReflection]]

--- a/gel/_internal/_qbmodel/_abstract/__init__.py
+++ b/gel/_internal/_qbmodel/_abstract/__init__.py
@@ -10,7 +10,7 @@ from ._base import (
     GelType,
     GelType_T,
     GelTypeMeta,
-    GelTypeMetadata,
+    PointerInfo,
 )
 
 from ._descriptors import (
@@ -21,7 +21,6 @@ from ._descriptors import (
     OptionalPointerDescriptor,
     OptionalPropertyDescriptor,
     PointerDescriptor,
-    PointerInfo,
     PropertyDescriptor,
     field_descriptor,
 )
@@ -62,7 +61,6 @@ __all__ = (
     "GelPrimitiveType",
     "GelType",
     "GelTypeMeta",
-    "GelTypeMetadata",
     "GelType_T",
     "LinkDescriptor",
     "ModelFieldDescriptor",

--- a/gel/_internal/_qbmodel/_abstract/_descriptors.py
+++ b/gel/_internal/_qbmodel/_abstract/_descriptors.py
@@ -7,13 +7,11 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
-import dataclasses
 import typing
 
 # XXX: get rid of this
 from pydantic._internal import _namespace_utils  # noqa: PLC2701
 
-from gel._internal import _edgeql
 from gel._internal import _qb
 from gel._internal import _typing_eval
 from gel._internal import _typing_inspect
@@ -183,16 +181,6 @@ class OptionalPointerDescriptor(PointerDescriptor[T_co, BT_co]):
         ) -> type[T_co] | T_co | None: ...
 
         def __set__(self, obj: Any, value: BT_co | None) -> None: ...
-
-
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class PointerInfo:
-    computed: bool = False
-    readonly: bool = False
-    has_props: bool = False
-    cardinality: _edgeql.Cardinality = _edgeql.Cardinality.One
-    annotation: type[Any] | None = None
-    kind: _edgeql.PointerKind | None = None
 
 
 class AnyPropertyDescriptor(PointerDescriptor[T_co, BT_co]):

--- a/gel/_internal/_qbmodel/_abstract/_objects.py
+++ b/gel/_internal/_qbmodel/_abstract/_objects.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from typing_extensions import Self
 
+import functools
 import weakref
 
 from gel._internal import _qb
@@ -227,7 +228,12 @@ class GelModel(
         @hybridmethod
         def __edgeql__(self) -> tuple[type, str]:
             if isinstance(self, type):
-                return self, _qb.toplevel_edgeql(self)
+                return self, _qb.toplevel_edgeql(
+                    self,
+                    splat_cb=functools.partial(
+                        _qb.get_object_type_splat, self
+                    ),
+                )
             else:
                 raise NotImplementedError(
                     f"{type(self)} instances are not queryable"

--- a/gel/_internal/_reflection/_enums.py
+++ b/gel/_internal/_reflection/_enums.py
@@ -4,17 +4,18 @@
 
 
 import enum
+from typing import final
+
+from gel._internal._polyfills._strenum import StrEnum
 
 
-class StrEnum(str, enum.Enum):
-    pass
-
-
+@final
 class SchemaPart(enum.Enum):
     STD = enum.auto()
     USER = enum.auto()
 
 
+@final
 class Cardinality(StrEnum):
     AtMostOne = "AtMostOne"
     One = "One"
@@ -36,6 +37,7 @@ class Cardinality(StrEnum):
         }
 
 
+@final
 class TypeKind(StrEnum):
     Array = "Array"
     Enum = "Enum"
@@ -48,17 +50,20 @@ class TypeKind(StrEnum):
     Pseudo = "Pseudo"
 
 
+@final
 class TypeModifier(StrEnum):
     SetOf = "SetOfType"
     Optional = "OptionalType"
     Singleton = "SingletonType"
 
 
+@final
 class PointerKind(StrEnum):
     Link = "Link"
     Property = "Property"
 
 
+@final
 class OperatorKind(StrEnum):
     Infix = "Infix"
     Postfix = "Postfix"
@@ -66,6 +71,7 @@ class OperatorKind(StrEnum):
     Ternary = "Ternary"
 
 
+@final
 class CallableParamKind(StrEnum):
     Variadic = "VariadicParam"
     NamedOnly = "NamedOnlyParam"

--- a/gel/_internal/_reflection/_support.py
+++ b/gel/_internal/_reflection/_support.py
@@ -39,6 +39,9 @@ class SchemaPath(pathlib.PurePosixPath):
     def as_quoted_schema_name(self) -> str:
         return "::".join(_edgeql.quote_ident(p) for p in self.parts)
 
+    def as_code(self, clsname: str = "SchemaPath") -> str:
+        return f"{clsname}({', '.join(repr(p) for p in self.parts)})"
+
 
 def parse_name(name: str) -> SchemaPath:
     return SchemaPath.from_schema_name(name)

--- a/gel/models/pydantic.py
+++ b/gel/models/pydantic.py
@@ -10,6 +10,7 @@ from pydantic import (
     computed_field,
 )
 
+from gel._internal._edgeql import Cardinality, PointerKind
 from gel._internal._lazyprop import LazyClassProperty
 from gel._internal._reflection import SchemaPath
 from gel._internal._typing_dispatch import dispatch_overload
@@ -19,6 +20,8 @@ from gel._internal._qb import (
     AnnotatedExpr,
     EmptyDirection,
     Direction,
+    GelPointerReflection,
+    GelTypeMetadata,
     ExprClosure,
     ExprCompatible,
     IndexOp,
@@ -36,7 +39,6 @@ from gel._internal._qbmodel._abstract import (
     GelType,
     GelType_T,
     GelTypeMeta,
-    GelTypeMetadata,
     PyConstType,
 )
 
@@ -80,6 +82,7 @@ __all__ = (
     "AnyTuple",
     "Array",
     "BaseScalar",
+    "Cardinality",
     "ComputedLinkWithProps",
     "ComputedMultiLink",
     "ComputedMultiLinkWithProps",
@@ -94,6 +97,7 @@ __all__ = (
     "GelLinkModel",
     "GelModel",
     "GelModelMeta",
+    "GelPointerReflection",
     "GelType",
     "GelTypeMeta",
     "GelTypeMetadata",
@@ -116,6 +120,7 @@ __all__ = (
     "OptionalLinkWithProps",
     "OptionalProperty",
     "PathAlias",
+    "PointerKind",
     "PrefixOp",
     "PrivateAttr",
     "Property",


### PR DESCRIPTION
Instead of going a roundabout way through `Annotated` type eval, just
emit pointer reflection information directly in `__gel_reflection__`.

This also includes shape and splat generalizations from aborted #682.
