### PR TITLE
qb: Always fetch link properties

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -2195,9 +2195,9 @@ class GeneratedSchemaModule(BaseGeneratedModule):
 
         if ptr.pointers is not None:
             kwargs["properties"] = self.format_list(
-                "({list})",
+                "{{{list}}}",
                 [
-                    self._reflect_pointer(prop, classes)
+                    f"{prop.name!r}: {self._reflect_pointer(prop, classes)}"
                     for prop in ptr.pointers
                 ],
                 extra_indent=1,

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -20,7 +20,7 @@ class GelPointerReflection:
     cardinality: _edgeql.Cardinality
     computed: bool
     readonly: bool
-    properties: tuple[GelPointerReflection, ...] | None
+    properties: dict[str, GelPointerReflection] | None
 
 
 class GelTypeMetadata:

--- a/gel/_internal/_qbmodel/_abstract/_expressions.py
+++ b/gel/_internal/_qbmodel/_abstract/_expressions.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeAliasType
 import dataclasses
 import functools
 
+from gel._internal import _edgeql
 from gel._internal import _qb
 from gel._internal._utils import Unspecified
 
@@ -163,9 +164,35 @@ def select(
             )
             shape_elements.append(shape_el)
         else:
+            el_expr = _qb.edgeql_qb_expr(kwarg, var=prefix_alias)
+            if isinstance(el_expr, _qb.ShapeOp):
+                ptrinfo = cls.__gel_reflection__.pointers[ptrname]
+                subshape = list(el_expr.shape.elements)
+                subshape_names = {el.name: el for el in subshape}
+                if (
+                    ptrinfo.kind is _edgeql.PointerKind.Link
+                    and ptrinfo.properties
+                ):
+                    for propname in ptrinfo.properties:
+                        lprop = f"@{propname}"
+                        if lprop not in subshape_names:
+                            subshape.append(
+                                _qb.ShapeElement(
+                                    name=lprop,
+                                    origin=el_expr.type,
+                                )
+                            )
+                    el_expr = dataclasses.replace(
+                        el_expr,
+                        shape=dataclasses.replace(
+                            el_expr.shape,
+                            elements=subshape,
+                        )
+                    )
+
             shape_el = _qb.ShapeElement(
                 name=ptrname,
-                expr=_qb.edgeql_qb_expr(kwarg, var=prefix_alias),
+                expr=el_expr,
                 origin=this_type,
             )
             shape_elements.append(shape_el)

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -661,7 +661,7 @@ class TestModelGenerator(tb.ModelTestCase):
         res = self.client.get(
             default.Raid.select(
                 name=True,
-                members=True,
+                members=lambda r: r.members.select(name=True, nickname=True),
             ).filter(name="Solo")
         )
         self.assertEqual(res.name, "Solo")


### PR DESCRIPTION
Always fetch link properties even on partial selects.  This greatly
simplifies dirty state tracking.

Fixes: #666
