### PR TITLE
Work around Pydantic perf issue

### DIFF
--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -108,6 +108,16 @@ class GelModelMeta(_model_construction.ModelMetaclass, _abstract.GelModelMeta):
                 super().__new__(mcls, name, bases, namespace, **kwargs),
             )
 
+        # Workaround for https://github.com/pydantic/pydantic/issues/11975
+        for base in reversed(cls.__mro__[1:]):
+            decinfos = base.__dict__.get("__pydantic_decorators__")
+            if decinfos is None:
+                try:
+                    decinfos = type(cls.__pydantic_decorators__)()
+                    base.__pydantic_decorators__ = decinfos  # type: ignore [attr-defined]
+                except TypeError:
+                    pass
+
         for fname, field in cls.__pydantic_fields__.items():
             if fname in cls.__annotations__:
                 if field.annotation is None:

--- a/gel/_internal/ruff.toml
+++ b/gel/_internal/ruff.toml
@@ -53,6 +53,7 @@ extend-ignore = [
     "S101",    # assert
     "S404",    # suspicious-subprocess-import
     "S603",    # subprocess-without-shell-equals-true
+    "SIM105",  # suppressible-exception
     "SIM117",  # multiple-with-statements
     "UP045",   # non-pep604-annotation-optional
 ]


### PR DESCRIPTION
This speeds up `import models` by 6.5x by avoiding needless decorator
scans on full MRO (see pydantic/pydantic#11975)
