### PR TITLE
models: Fix cached stdlib model regen

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -153,6 +153,10 @@ class PydanticModelsGenerator(AbstractCodeGenerator):
 
             self._write_state(db_state, outdir)
 
+            for fn in list(std_manifest):
+                # Also keep the directories
+                std_manifest.update(fn.parents)
+
             _dirsync.dirsync(outdir, models_root, keep=std_manifest)
 
         self.print_msg(f"{C.GREEN}{C.BOLD}Done.{C.ENDC}")
@@ -265,9 +269,10 @@ class SchemaGenerator:
 
         files = set()
         for mod, has_submodules in std_modules.items():
+            modpath = get_modpath(mod, ModuleAspect.MAIN)
+            as_pkg = mod_is_package(modpath, part) or has_submodules
             for aspect in ModuleAspect.__members__.values():
                 modpath = get_modpath(mod, aspect)
-                as_pkg = mod_is_package(modpath, part) or has_submodules
                 files.add(mod_filename(modpath, as_pkg=as_pkg))
 
         common_modpath = get_common_types_modpath(self._schema_part)

--- a/gel/_internal/_dirsync.py
+++ b/gel/_internal/_dirsync.py
@@ -44,7 +44,7 @@ def dirsync(
     remove_files: set[Path] = set()
     remove_dirs: set[Path] = set()
 
-    keep_paths = {str(Path(p)) for p in keep}
+    keep_paths = {Path(p) for p in keep}
 
     # schedule base directory creation
     if not dst_path.exists():
@@ -78,18 +78,19 @@ def dirsync(
                 copy_files.append((src_file, dst_file))
 
     # scan destination for removals
-    for root, dirs, files in os.walk(dst_path, topdown=False):
-        rel = Path(root).relative_to(dst_path)
+    for dirpath_str, dirs, files in os.walk(dst_path, topdown=False):
+        dirpath = Path(dirpath_str)
+        rel = dirpath.relative_to(dst_path)
         src_root = src_path / rel
 
         for f in files:
-            dst_file = Path(root) / f
-            if not (src_root / f).exists() and f not in keep_paths:
+            dst_file = dirpath / f
+            if not (src_root / f).exists() and (rel / f) not in keep_paths:
                 remove_files.add(dst_file)
 
         for d in dirs:
-            dst_dir = Path(root) / d
-            if not (src_root / d).exists() and d not in keep_paths:
+            dst_dir = dirpath / d
+            if not (src_root / d).exists() and (rel / d) not in keep_paths:
                 remove_dirs.add(dst_dir)
 
     # execute creations


### PR DESCRIPTION
Dry run models manifest is generated incorrectly and also `dirsync`s
`keep` handling is broken.  Fix both.
