### PR TITLE
fastapi: use JSON instead of WWW-form

### DIFF
--- a/gel/_internal/_integration/_fastapi/_auth/email_password.py
+++ b/gel/_internal/_integration/_fastapi/_auth/email_password.py
@@ -282,7 +282,7 @@ class EmailPassword(Installable):
             summary=self.sign_up_summary.value,
         )
         async def sign_up(
-            sign_up_body: Annotated[SignUpBody, fastapi.Form()],
+            sign_up_body: Annotated[SignUpBody, fastapi.Body()],
             request: fastapi.Request,
         ) -> fastapi.Response:
             result = await self._core.sign_up(
@@ -360,7 +360,7 @@ class EmailPassword(Installable):
             summary=self.sign_in_summary.value,
         )
         async def sign_in(
-            sign_in_body: Annotated[SignInBody, fastapi.Form()],
+            sign_in_body: Annotated[SignInBody, fastapi.Body()],
             request: fastapi.Request,
         ) -> fastapi.Response:
             result = await self._core.sign_in(
@@ -510,7 +510,7 @@ class EmailPassword(Installable):
         )
         async def send_password_reset(
             send_password_reset_body: Annotated[
-                SendPasswordResetBody, fastapi.Form()
+                SendPasswordResetBody, fastapi.Body()
             ],
             request: fastapi.Request,
         ) -> fastapi.Response:
@@ -589,7 +589,7 @@ class EmailPassword(Installable):
         )
         async def reset_password(
             request: fastapi.Request,
-            reset_password_body: Annotated[ResetPasswordBody, fastapi.Form()],
+            reset_password_body: Annotated[ResetPasswordBody, fastapi.Body()],
             verifier: Optional[str] = fastapi.Depends(
                 self._auth.pkce_verifier
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ doc = [
 ]
 ai = ['httpx>=0.27.0', 'httpx-sse~=0.4.0']
 auth = ['httpx>=0.27.0']
-fastapi = ['fastapi', 'python-multipart', 'pyjwt']
+fastapi = ['fastapi', 'pyjwt']
 
 [project.urls]
 homepage = "https://www.geldata.com"


### PR DESCRIPTION
Given that [FastAPI doesn't support](https://github.com/fastapi/fastapi/discussions/7786#discussioncomment-5144191) both JSON and WWW-form at the same time, let's choose the more popular one as for now.