### PR TITLE
gel: Make sure we don't generate names that conflict with Python dunders

### DIFF
--- a/tests/dbsetup/orm.edgeql
+++ b/tests/dbsetup/orm.edgeql
@@ -80,7 +80,7 @@ insert StackableLoot {
 };
 
 insert KitchenSink {
-    p_str := 'hello world',
+    str := 'hello world',
     p_multi_str := {'brown', 'fox'},
 
     array := ["foo"],

--- a/tests/dbsetup/orm.gel
+++ b/tests/dbsetup/orm.gel
@@ -121,7 +121,7 @@ type StepPath {
 }
 
 type KitchenSink {
-    required p_str: str;
+    required str: str;
     required multi p_multi_str: str;
     p_opt_str: str;
     multi p_opt_multi_str: str;

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -1305,7 +1305,7 @@ class TestModelGenerator(tb.ModelTestCase):
         # insert an object with an optional single: with link props
 
         ks = default.KitchenSink(
-            p_str="coll_test_1",
+            str="coll_test_1",
             p_multi_str=["1", "222"],
             array=["foo", "bar"],
             p_multi_arr=[["foo"], ["bar"]],
@@ -1317,7 +1317,7 @@ class TestModelGenerator(tb.ModelTestCase):
         self.client.save(ks)
 
         # Re-fetch and verify
-        ks = self.client.get(default.KitchenSink.filter(p_str="coll_test_1"))
+        ks = self.client.get(default.KitchenSink.filter(str="coll_test_1"))
         self.assertEqual(sorted(ks.p_multi_str), ["1", "222"])
         self.assertEqual(ks.array, ["foo", "bar"])
         self.assertEqual(sorted(ks.p_multi_arr), [["bar"], ["foo"]])
@@ -1331,7 +1331,7 @@ class TestModelGenerator(tb.ModelTestCase):
         ks.p_multi_str.remove("1")
         self.client.save(ks)
 
-        ks3 = self.client.get(default.KitchenSink.filter(p_str="coll_test_1"))
+        ks3 = self.client.get(default.KitchenSink.filter(str="coll_test_1"))
         self.assertEqual(sorted(ks3.p_multi_str), ["222", "zzz", "zzz"])
 
     @tb.typecheck


### PR DESCRIPTION
The `builtins` module was disambiguated as `__builtins__` which is a
name used to represent current module's dict.

Fixes: #700
