### PR TITLE
Make complex model instantiation 10x faster

### DIFF
--- a/gel/_internal/_dlist.py
+++ b/gel/_internal/_dlist.py
@@ -74,6 +74,8 @@ class AbstractTrackedList(
         else:
             self._initial_items = []
             self._items = []
+            # 'extend' is optimized in _UpcastingDistinctList
+            # for use in __init__
             self.extend(iterable)
 
     def _ensure_snapshot(self) -> None:
@@ -368,6 +370,8 @@ class AbstractDistinctList(AbstractTrackedList[_HT_co]):
             self._set.add(item)
         except TypeError:
             pass
+        else:
+            return
 
         assert self._unhashables is not None
         self._unhashables[id(item)] = item
@@ -375,9 +379,12 @@ class AbstractDistinctList(AbstractTrackedList[_HT_co]):
     def _untrack_item(self, item: _HT_co) -> None:  # type: ignore [misc]
         assert self._set is not None
         try:
-            self._set.discard(item)
-        except TypeError:
+            self._set.remove(item)
+        except (TypeError, KeyError):
+            # Either unhashable or not in the list
             pass
+        else:
+            return
 
         assert self._unhashables is not None
         self._unhashables.pop(id(item), None)

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -545,6 +545,7 @@ OptionalComputedLinkWithProps = TypeAliasType(
 class _UpcastingDistinctList(
     _dlist.DistinctList[_PT_co], Generic[_PT_co, _BMT_co]
 ):
+    # Mapping of object IDs to ProxyModels that wrap them.
     _wrapped_index: dict[int, _PT_co] | None = None
 
     def _init_tracking(self) -> None:
@@ -577,37 +578,122 @@ class _UpcastingDistinctList(
         else:
             return id(item) in self._wrapped_index
 
-    def _check_value(self, value: Any) -> _PT_co:
-        cls = type(self)
+    def extend(self, values: Iterable[_PT_co | _BMT_co]) -> None:
+        # An optimized version of `extend()`
 
+        if not values:
+            # empty list? easy return
+            return
+
+        if values is self:
+            values = list(values)
+
+        self._ensure_snapshot()
+
+        cls = type(self)
         t = cls.type
+
+        assert self._wrapped_index is not None
+        assert self._set is not None
+        assert self._unhashables is not None
+
+        # For an empty list we can call one extend() call instead
+        # of slow iterative appends.
+        fast_extend = len(self._wrapped_index) == 0
+
+        for v in values:
+            if type(v) is t.__proxy_of__:
+                # Fast path -- `v` is an instance of the base type.
+                # It has no link props, so wrap it in a proxy in
+                # a fast way.
+                proxy = t.__gel_proxy_construct__(v, {})
+                obj = v
+            else:
+                proxy, obj = self._cast_value(v)
+
+            oid = id(obj)
+            try:
+                existing_proxy = self._wrapped_index[oid]
+            except KeyError:
+                self._wrapped_index[oid] = proxy
+            else:
+                if (
+                    existing_proxy.__linkprops__.__dict__
+                    != proxy.__linkprops__.__dict__
+                ):
+                    raise ValueError(
+                        f"the list already contains {v!r} with "
+                        f"a different set of link properties"
+                    )
+
+            try:
+                self._set.add(proxy)
+            except TypeError:
+                self._unhashables[id(proxy)] = proxy
+
+            if not fast_extend:
+                self._items.append(proxy)
+
+        if fast_extend:
+            self._items.extend(self._wrapped_index.values())
+
+    def _cast_value(self, value: Any) -> tuple[_PT_co, _BMT_co]:
+        cls = type(self)
+        t = cls.type
+
         assert issubclass(t, ProxyModel)
 
-        if not isinstance(value, t):
-            if not isinstance(value, ProxyModel) and isinstance(
-                value, t.__proxy_of__
-            ):
-                value = t(value)
-            else:
-                raise ValueError(
-                    f"{cls!r} accepts only values of type {t.__name__} "
-                    f"or {t.__proxy_of__.__name__}, got {type(value)!r}",
-                )
+        if type(value) is t.__proxy_of__:
+            # Fast path before we make all expensive isinstance calls.
+            return (
+                t.__gel_proxy_construct__(value, {}),
+                value,
+            )  # type: ignore [return-value]
+
+        if type(value) is t:
+            # It's a correct proxy for this link... return as is.
+            return value, value._p__obj__  # type: ignore [return-value]
+
+        if not isinstance(value, ProxyModel) and isinstance(
+            value, t.__proxy_of__
+        ):
+            # It's not a proxy, but the object is of the correct type --
+            # re-wrap it in a correct proxy.
+            return (
+                t.__gel_proxy_construct__(value, {}),
+                value,
+            )  # type: ignore [return-value]
+
+        raise ValueError(
+            f"{cls!r} accepts only values of type {t.__name__} "
+            f"or {t.__proxy_of__.__name__}, got {type(value)!r}",
+        )
+
+    def _check_value(self, value: Any) -> _PT_co:
+        proxy, obj = self._cast_value(value)
+
+        # We have to check if a proxy around the same object is already
+        # present in the list.
+        self._init_tracking()
+        assert self._wrapped_index is not None
+        try:
+            existing_proxy = self._wrapped_index[id(obj)]
+        except KeyError:
+            return proxy
+
+        assert isinstance(existing_proxy, ProxyModel)
 
         if (
-            sub := self._find_proxied_obj(value)
-        ) is not None and sub is not value:
-            assert isinstance(sub, ProxyModel)
-            if sub.__linkprops__.__dict__ != value.__linkprops__.__dict__:
-                raise ValueError(
-                    f"the list already contains {value!r} with "
-                    f" a different set of link properties"
-                )
-            # Return the already present identical proxy instead of inserting
-            # another one
-            return sub  # type: ignore [return-value]
-
-        return value  # type: ignore [no-any-return]
+            existing_proxy.__linkprops__.__dict__
+            != proxy.__linkprops__.__dict__
+        ):
+            raise ValueError(
+                f"the list already contains {value!r} with "
+                f" a different set of link properties"
+            )
+        # Return the already present identical proxy instead of inserting
+        # another one
+        return existing_proxy  # type: ignore [return-value]
 
     def _find_proxied_obj(self, item: _PT_co | _BMT_co) -> _PT_co | None:
         self._init_tracking()
@@ -703,6 +789,13 @@ class _MultiLink(
             )
 
 
+@functools.cache
+def _make_dlist_type(
+    types: tuple[type[_PT_co], type[_BMT_co]],
+) -> type[_UpcastingDistinctList[_PT_co, _BMT_co]]:
+    return _UpcastingDistinctList[types[0], types[1]]  # type: ignore [valid-type]
+
+
 class _MultiLinkWithProps(
     _MultiPointer[_PT_co, _BMT_co],
     _abstract.LinkDescriptor[_PT_co, _BMT_co],
@@ -732,7 +825,7 @@ class _MultiLinkWithProps(
         cls,
         type_args: tuple[type[Any]] | tuple[type[Any], type[Any]],
     ) -> _dlist.DistinctList[_MT_co]:
-        return _UpcastingDistinctList[type_args[0], type_args[1]]  # type: ignore [return-value, valid-type]
+        return _make_dlist_type(type_args)  # type: ignore [return-value]
 
     @classmethod
     def _validate(
@@ -740,13 +833,14 @@ class _MultiLinkWithProps(
         value: Any,
         generic_args: tuple[type[Any], type[Any]],
     ) -> _UpcastingDistinctList[_PT_co, _BMT_co]:
-        lt: type[_UpcastingDistinctList[_PT_co, _BMT_co]] = (
-            _UpcastingDistinctList[
-                generic_args[0],  # type: ignore [valid-type]
-                generic_args[1],  # type: ignore [valid-type]
-            ]
+        lt: type[_UpcastingDistinctList[_PT_co, _BMT_co]] = _make_dlist_type(
+            generic_args
         )
-        if isinstance(value, lt):
+        if type(lt) is list:  # type: ignore [comparison-overlap]
+            # Optimization for the most common scenario - user passes
+            # a list of objects to the constructor.
+            return lt(value)
+        elif isinstance(value, lt):
             return value
         elif isinstance(value, (list, _dlist.DistinctList)):
             return lt(value)

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -34,7 +34,6 @@ from pydantic_core import core_schema
 from gel._internal import _dlist
 from gel._internal import _edgeql
 from gel._internal import _typing_inspect
-from gel._internal import _unsetid
 
 from gel._internal._qbmodel import _abstract
 

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -582,7 +582,7 @@ class _UpcastingDistinctList(
         # An optimized version of `extend()`
 
         if not values:
-            # empty list? easy return
+            # Empty list => early return
             return
 
         if values is self:
@@ -604,7 +604,7 @@ class _UpcastingDistinctList(
         for v in values:
             if type(v) is t.__proxy_of__:
                 # Fast path -- `v` is an instance of the base type.
-                # It has no link props, so wrap it in a proxy in
+                # It has no link props, wrap it in a proxy in
                 # a fast way.
                 proxy = t.__gel_proxy_construct__(v, {})
                 obj = v

--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -118,6 +118,22 @@ class GelModelMeta(_model_construction.ModelMetaclass, _abstract.GelModelMeta):
 
         return result
 
+    # We don't need the complicated isinstance checking inherited
+    # by Pydantic's ModelMetaclass from abc.Meta -- it's incredibly
+    # slow. For GelModels we can just use the built-in
+    # type.__instancecheck__ and type.__subclasscheck__. It's not
+    # clear why an ABC-level "compatibility" would even be useful
+    # for GelModels given how specialized they are.
+    #
+    # Context: without this, IMDBench's data loading takes 2x longer.
+    #
+    # Alternatively, we could just overload these for ProxyModel --
+    # that's where most impact is. So if *you*, the reader of this code,
+    # have a use case for supporting the broader isinstance/issubclass
+    # semantics please onen an issue and let us know.
+    __instancecheck__ = type.__instancecheck__  # type: ignore [assignment]
+    __subclasscheck__ = type.__subclasscheck__  # type: ignore [assignment]
+
 
 def _resolve_pointers(cls: type[GelSourceModel]) -> dict[str, type[GelType]]:
     if not cls.__pydantic_complete__ and cls.model_rebuild() is False:

--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -381,6 +381,9 @@ class GelModel(
                 if field.init is False and field_name != "id":
                     self.__dict__.pop(field_name, None)
 
+    def __gel_is_new__(self) -> bool:
+        return self.id is UNSET_UUID
+
     def __gel_commit__(self, new_id: uuid.UUID | None = None) -> None:
         if new_id is not None:
             if self.id is not UNSET_UUID:

--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -523,6 +523,21 @@ class ProxyModel(GelModel, Generic[_MT_co]):
                 schema=handler.generate_schema(cls.__proxy_of__),
             )
 
+    @classmethod
+    def __gel_proxy_construct__(
+        cls,
+        obj: _MT_co,  # type: ignore [misc]
+        lprops: dict[str, Any],
+    ) -> Self:
+        pnv = cls.__gel_model_construct__(None)
+        object.__setattr__(pnv, "_p__obj__", obj)
+        object.__setattr__(
+            pnv,
+            "__linkprops__",
+            cls.__lprops__.__gel_model_construct__(lprops),
+        )
+        return pnv
+
     def __repr_name__(self) -> str:
         cls = type(self)
         base_cls = cls.__bases__[0]

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -943,7 +943,7 @@ class SaveExecutor:
                         f"}})"
                     )
 
-                else:  # noqa: PLR5501
+                else:
                     if ch.info.cardinality.is_optional():
                         arg = add_arg(
                             "array<tuple<std::uuid>>",

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -801,21 +801,6 @@ class SaveExecutor:
         else:
             return self.object_ids[id(obj)]
 
-    def _compile_link_prop_expr(
-        self,
-        proxy: ProxyModel[GelModel],
-        obj_ql: str,
-    ) -> str:
-        if proxy is None:
-            return obj_ql
-
-        changes = proxy.__gel_get_changed_fields__()
-        if not changes:
-            return obj_ql
-
-        # for field_name in changes:
-        raise RuntimeError
-
     def _compile_change(
         self, change: ModelChange, /, *, for_insert: bool
     ) -> QueryWithArgs:

--- a/gel/_internal/_unsetid.py
+++ b/gel/_internal/_unsetid.py
@@ -3,16 +3,24 @@
 # SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
 
 from __future__ import annotations
-from typing import (
-    Any,
-)
+from typing import Any
 
 import uuid
+
+
+__all__ = ["UNSET_UUID"]
 
 
 class _UnsetUUID(uuid.UUID):
     """A UUID subclass that only lets you str()/repr() it; everything
     else errors out."""
+
+    def __new__(cls) -> _UnsetUUID:  # noqa: PYI034
+        global _UNSET_UUID  # noqa: PLW0603
+        if _UNSET_UUID is not None:
+            return _UNSET_UUID
+        _UNSET_UUID = super().__new__(cls)
+        return _UNSET_UUID
 
     def __init__(self) -> None:
         # Create a “zero” UUID under the hood. It doesn't really matter what it
@@ -36,20 +44,37 @@ class _UnsetUUID(uuid.UUID):
             "__repr__",
             "__setstate__",
             "__str__",
+            "__copy__",
+            "__deepcopy__",
             "int",
         }:
             return object.__getattribute__(self, name)
-        elif name in {
-            "__copy__",
-            "__deepcopy__",
-        }:
-            raise AttributeError(name)
         else:
             raise ValueError(f"_UnsetUUID.{name}: id is not set")
+
+    def __copy__(self) -> _UnsetUUID:
+        return self
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> _UnsetUUID:
+        return self
 
     def __getstate__(self) -> object:
         return {"int": 0}
 
+    def __hash__(self) -> int:
+        # We don't want unset uuids to be hashable or they will
+        # cause bugs when used as keys in a collection.
+        raise TypeError("UNSET_UUID is unhashable")
+
+    def __eq__(self, other: object) -> bool:
+        # Since unset uuids aren't hashable, the equality
+        # check can only mirror the identity check.
+        if isinstance(other, uuid.UUID):
+            return self is other
+        return NotImplemented
+
+
+_UNSET_UUID: _UnsetUUID | None = None
 
 # single shared sentinel
 UNSET_UUID: uuid.UUID = _UnsetUUID()

--- a/gel/_internal/ruff.toml
+++ b/gel/_internal/ruff.toml
@@ -57,4 +57,5 @@ extend-ignore = [
     "SIM105",  # suppressible-exception
     "SIM117",  # multiple-with-statements
     "UP045",   # non-pep604-annotation-optional
+    "PLR5501", # collapsible-else-if
 ]

--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -524,11 +524,12 @@ class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
             async with tx:
                 executor = make_executor()
 
-                for batch in executor:
-                    for query, args in batch:
-                        await tx.send_query_required_single(query, *args)
-                    ids = await tx.wait()
-                    executor.feed_ids(ids)
+                for batches in executor:
+                    for batch in batches:
+                        await tx.send_query(batch.query, batch.args)
+                    batch_ids = await tx.wait()
+                    for ids, batch in zip(batch_ids, batches, strict=True):
+                        batch.feed_ids(ids)
 
                 executor.commit()
 

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -550,11 +550,12 @@ class Client(base_client.BaseClient, abstract.Executor):
             with tx:
                 executor = make_executor()
 
-                for batch in executor:
-                    for query, args in batch:
-                        tx.send_query_required_single(query, *args)
-                    ids = tx.wait()
-                    executor.feed_ids(ids)
+                for batches in executor:
+                    for batch in batches:
+                        tx.send_query(batch.query, batch.args)
+                    batch_ids = tx.wait()
+                    for ids, batch in zip(batch_ids, batches, strict=True):
+                        batch.feed_ids(ids)
 
                 executor.commit()
 

--- a/gel/protocol/codecs/object.pyx
+++ b/gel/protocol/codecs/object.pyx
@@ -313,15 +313,7 @@ cdef class ObjectCodec(BaseNamedRecordCodec):
 
         if return_type_proxy is not None:
             nested = current_ret_type.__gel_model_construct__(result_dict)
-            result = return_type_proxy.__gel_model_construct__(None)
-            object.__setattr__(result, '_p__obj__', nested)
-            object.__setattr__(
-                result,
-                '__linkprops__',
-                return_type_proxy.__lprops__.__gel_model_construct__(
-                    lprops_dict
-                )
-            )
+            result = return_type_proxy.__gel_proxy_construct__(nested, lprops_dict)
         else:
             result = current_ret_type.__gel_model_construct__(result_dict)
 

--- a/tests/test_distinct_list.py
+++ b/tests/test_distinct_list.py
@@ -188,28 +188,6 @@ class TestDistinctList(unittest.TestCase):
         lst = AnyList()
         self.assertIsInstance(lst, MutableSequence)
 
-    # promote_unhashables method
-    def test_dlist_promote_unhashables(self):
-        u = ToggleHash()
-        u2 = ToggleHash()
-        u3 = ToggleHash()
-        u4 = ToggleHash()
-        lst = AnyList([u, u2, u3, u4])
-        self.assertIn(id(u), lst._unhashables)
-        u.make_hashable()
-        lst.promote_unhashables(u)
-        self.assertNotIn(id(u), lst._unhashables)
-        self.assertIn(u, lst._set)
-        u2.make_hashable()
-        lst.promote_unhashables()
-        self.assertNotIn(id(u2), lst._unhashables)
-        self.assertIn(u2, lst._set)
-        self.assertIn(id(u3), lst._unhashables)
-        u3.make_hashable()
-        u4.make_hashable(id(u3))
-        lst.promote_unhashables()
-        self.assertEqual(list(lst), [u, u2, u3])
-
     # Type enforcement errors
     def test_dlist_type_enforcement(self):
         il = IntList()

--- a/tests/test_unsetid.py
+++ b/tests/test_unsetid.py
@@ -1,0 +1,33 @@
+import unittest
+
+import copy
+import uuid
+import pickle
+
+from gel._internal._unsetid import UNSET_UUID, _UnsetUUID
+
+
+class TestUnsetID(unittest.TestCase):
+    def test_unsetid_singleton(self):
+        i1 = _UnsetUUID()
+        self.assertIs(UNSET_UUID, i1)
+
+    def test_unsetid_hash(self):
+        with self.assertRaisesRegex(TypeError, "UNSET_UUID is unhashable"):
+            hash(UNSET_UUID)
+
+    def test_unsetid_eq(self):
+        u = uuid.uuid4()
+        self.assertNotEqual(UNSET_UUID, u)
+        self.assertEqual(UNSET_UUID, UNSET_UUID)
+        self.assertNotEqual(UNSET_UUID, None)
+        self.assertNotEqual(UNSET_UUID, 123)
+
+    def test_unsetid_copy(self):
+        self.assertIs(copy.copy(UNSET_UUID), UNSET_UUID)
+        self.assertIs(copy.deepcopy(UNSET_UUID), UNSET_UUID)
+
+    def test_unsetid_pickle(self):
+        p = pickle.dumps(UNSET_UUID)
+        unp = pickle.loads(p)
+        self.assertIs(UNSET_UUID, unp)


### PR DESCRIPTION
This is pretty much as fast as it can be now without cythonizing the code. Another option would be to make ProxyModel wrapping lazy in `_UpcastingDistinctList` but that has implementation complexity costs.