### PR TITLE
fastapi: fix annotations in hooks

### DIFF
--- a/gel/_internal/_integration/_fastapi/_utils.py
+++ b/gel/_internal/_integration/_fastapi/_utils.py
@@ -192,10 +192,13 @@ class HookInstance(Generic[T, S]):
             )
 
         def wrapper(func: Handler[T]) -> Handler[T]:
+            call = functools.partial(func, cast("T", None))
+            # __globals__ is used by FastAPI get_typed_signature()
+            call.__globals__ = func.__globals__  # type: ignore [attr-defined]
             dependant = dep_utils.get_dependant(
                 path=self._path,
                 name=self._name,
-                call=functools.partial(func, cast("T", None)),
+                call=call,
             )
 
             if dependant.path_params:


### PR DESCRIPTION
This fixes the failure to evaluate forward references in hooks, e.g.:

```
from __future__ import annotations

@g.auth.on_new_identity
async def on_new_identity(
    result: tuple[uuid.UUID, gel.auth.TokenData | None],
    client: gel.fastapi.Client,
...
```

Fixes #708 