### PR TITLE
Optimizations and semantics fixes

### DIFF
--- a/gel/_internal/_dlist.py
+++ b/gel/_internal/_dlist.py
@@ -74,7 +74,7 @@ class AbstractTrackedList(
         else:
             self._initial_items = []
             self._items = []
-            # 'extend' is optimized in _UpcastingDistinctList
+            # 'extend' is optimized in ProxyDistinctList
             # for use in __init__
             self.extend(iterable)
 

--- a/gel/_internal/_qbmodel/_abstract/_descriptors.py
+++ b/gel/_internal/_qbmodel/_abstract/_descriptors.py
@@ -155,7 +155,16 @@ class ModelFieldDescriptor(_qb.AbstractFieldDescriptor):
             raise AttributeError(f"{self.__gel_name__!r} is not set")
         else:
             assert owner is not None
-            return self.get(owner)
+            cache_attr = f"__cached_path_{self.__gel_name__}"
+
+            try:
+                return object.__getattribute__(owner, cache_attr)
+            except AttributeError:
+                pass
+
+            path = self.get(owner)
+            setattr(owner, cache_attr, path)
+            return path
 
 
 def field_descriptor(

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -8,18 +8,15 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
-    cast,
     Annotated,
     Any,
     Generic,
-    SupportsIndex,
     TypeVar,
     overload,
 )
 
 from typing_extensions import (
     TypeAliasType,
-    Self,
 )
 
 import functools
@@ -38,12 +35,13 @@ from gel._internal import _typing_inspect
 from gel._internal._qbmodel import _abstract
 
 from ._models import GelModel, ProxyModel
+from ._pdlist import ProxyDistinctList
 
 from gel._internal._unsetid import UNSET_UUID
 
 if TYPE_CHECKING:
     from typing_extensions import Never
-    from collections.abc import Sequence, Iterable
+    from collections.abc import Sequence
 
 
 _T_co = TypeVar("_T_co", covariant=True)
@@ -542,210 +540,6 @@ OptionalComputedLinkWithProps = TypeAliasType(
     type_params=(_PT_co, _MT_co),
 )
 
-ll_getattr = object.__getattribute__
-
-
-class _UpcastingDistinctList(
-    _dlist.DistinctList[_PT_co], Generic[_PT_co, _BMT_co]
-):
-    # Mapping of object IDs to ProxyModels that wrap them.
-    _wrapped_index: dict[int, _PT_co] | None = None
-
-    def _init_tracking(self) -> None:
-        super()._init_tracking()
-
-        if self._wrapped_index is None:
-            self._wrapped_index = {}
-            for item in self._items:
-                assert isinstance(item, ProxyModel)
-                wrapped = ll_getattr(item, "_p__obj__")
-                self._wrapped_index[id(wrapped)] = cast("_PT_co", item)
-
-    def _track_item(self, item: _PT_co) -> None:  # type: ignore [misc]
-        assert isinstance(item, ProxyModel)
-        super()._track_item(cast("_PT_co", item))
-        assert self._wrapped_index is not None
-        wrapped = ll_getattr(item, "_p__obj__")
-        self._wrapped_index[id(wrapped)] = cast("_PT_co", item)
-
-    def _untrack_item(self, item: _PT_co) -> None:  # type: ignore [misc]
-        assert isinstance(item, ProxyModel)
-        super()._untrack_item(cast("_PT_co", item))
-        assert self._wrapped_index is not None
-        wrapped = ll_getattr(item, "_p__obj__")
-        self._wrapped_index.pop(id(wrapped), None)
-
-    def _is_tracked(self, item: _PT_co | _BMT_co) -> bool:
-        self._init_tracking()
-        assert self._wrapped_index is not None
-
-        if isinstance(item, ProxyModel):
-            return id(item._p__obj__) in self._wrapped_index
-        else:
-            return id(item) in self._wrapped_index
-
-    def extend(self, values: Iterable[_PT_co | _BMT_co]) -> None:
-        # An optimized version of `extend()`
-
-        if not values:
-            # Empty list => early return
-            return
-
-        if values is self:
-            values = list(values)
-
-        self._ensure_snapshot()
-
-        cls = type(self)
-        t = cls.type
-
-        assert self._wrapped_index is not None
-        assert self._set is not None
-        assert self._unhashables is not None
-
-        # For an empty list we can call one extend() call instead
-        # of slow iterative appends.
-        fast_extend = len(self._wrapped_index) == 0
-
-        for v in values:
-            tv = type(v)
-            if tv is t.__proxy_of__:
-                # Fast path -- `v` is an instance of the base type.
-                # It has no link props, wrap it in a proxy in
-                # a fast way.
-                proxy = t.__gel_proxy_construct__(v, {})
-                obj = v
-            elif tv is t:
-                # Another fast path -- `v` is already the correct proxy.
-                proxy = v  # type: ignore [assignment]
-                obj = ll_getattr(v, "_p__obj__")
-            else:
-                proxy, obj = self._cast_value(v)
-
-            oid = id(obj)
-            existing_proxy = self._wrapped_index.get(oid)
-            if existing_proxy is None:
-                self._wrapped_index[oid] = proxy
-            else:
-                if (
-                    existing_proxy.__linkprops__.__dict__
-                    != proxy.__linkprops__.__dict__
-                ):
-                    raise ValueError(
-                        f"the list already contains {v!r} with "
-                        f"a different set of link properties"
-                    )
-
-            if obj.id is UNSET_UUID:
-                self._unhashables[id(proxy)] = proxy
-            else:
-                self._set.add(proxy)
-
-            if not fast_extend:
-                self._items.append(proxy)
-
-        if fast_extend:
-            self._items.extend(self._wrapped_index.values())
-
-    def _cast_value(self, value: Any) -> tuple[_PT_co, _BMT_co]:
-        cls = type(self)
-        t = cls.type
-
-        assert issubclass(t, ProxyModel)
-
-        tp_value = type(value)
-
-        if tp_value is t.__proxy_of__:
-            # Fast path before we make all expensive isinstance calls.
-            return (
-                t.__gel_proxy_construct__(value, {}),
-                value,
-            )  # type: ignore [return-value]
-
-        if tp_value is t:
-            # It's a correct proxy for this link... return as is.
-            return (
-                value,
-                ll_getattr(value, "_p__obj__"),
-            )
-
-        if not isinstance(value, ProxyModel) and isinstance(
-            value, t.__proxy_of__
-        ):
-            # It's not a proxy, but the object is of the correct type --
-            # re-wrap it in a correct proxy.
-            return (
-                t.__gel_proxy_construct__(value, {}),
-                value,
-            )  # type: ignore [return-value]
-
-        raise ValueError(
-            f"{cls!r} accepts only values of type {t.__name__} "
-            f"or {t.__proxy_of__.__name__}, got {tp_value!r}",
-        )
-
-    def _check_value(self, value: Any) -> _PT_co:
-        proxy, obj = self._cast_value(value)
-
-        # We have to check if a proxy around the same object is already
-        # present in the list.
-        self._init_tracking()
-        assert self._wrapped_index is not None
-        try:
-            existing_proxy = self._wrapped_index[id(obj)]
-        except KeyError:
-            return proxy
-
-        assert isinstance(existing_proxy, ProxyModel)
-
-        if (
-            existing_proxy.__linkprops__.__dict__
-            != proxy.__linkprops__.__dict__
-        ):
-            raise ValueError(
-                f"the list already contains {value!r} with "
-                f" a different set of link properties"
-            )
-        # Return the already present identical proxy instead of inserting
-        # another one
-        return existing_proxy  # type: ignore [return-value]
-
-    def _find_proxied_obj(self, item: _PT_co | _BMT_co) -> _PT_co | None:
-        self._init_tracking()
-        assert self._wrapped_index is not None
-
-        if isinstance(item, ProxyModel):
-            item = item._p__obj__
-
-        return self._wrapped_index.get(id(item), None)
-
-    def clear(self) -> None:
-        super().clear()
-        self._wrapped_index = None
-
-    if TYPE_CHECKING:
-
-        def append(self, value: _PT_co | _BMT_co) -> None: ...
-        def insert(
-            self, index: SupportsIndex, value: _PT_co | _BMT_co
-        ) -> None: ...
-        def __setitem__(
-            self,
-            index: SupportsIndex | slice,
-            value: _PT_co | _BMT_co | Iterable[_PT_co | _BMT_co],
-        ) -> None: ...
-        def extend(self, values: Iterable[_PT_co | _BMT_co]) -> None: ...
-        def remove(self, value: _PT_co | _BMT_co) -> None: ...
-        def index(
-            self,
-            value: _PT_co | _BMT_co,
-            start: SupportsIndex = 0,
-            stop: SupportsIndex | None = None,
-        ) -> int: ...
-        def count(self, value: _PT_co | _BMT_co) -> int: ...
-        def __add__(self, other: Iterable[_PT_co | _BMT_co]) -> Self: ...
-        def __iadd__(self, other: Iterable[_PT_co | _BMT_co]) -> Self: ...
-
 
 class _ComputedMultiLink(
     _ComputedMultiPointer[_MT_co, _BMT_co],
@@ -816,13 +610,13 @@ class _MultiLinkWithProps(
         @overload
         def __get__(
             self, obj: object, objtype: Any = None
-        ) -> _UpcastingDistinctList[_PT_co, _BMT_co]: ...
+        ) -> ProxyDistinctList[_PT_co, _BMT_co]: ...
 
         def __get__(
             self,
             obj: Any,
             objtype: Any = None,
-        ) -> type[_PT_co] | _UpcastingDistinctList[_PT_co, _BMT_co] | None: ...
+        ) -> type[_PT_co] | ProxyDistinctList[_PT_co, _BMT_co] | None: ...
 
         def __set__(
             self, obj: Any, value: Sequence[_PT_co | _BMT_co]
@@ -833,7 +627,7 @@ class _MultiLinkWithProps(
         cls,
         type_args: tuple[type[Any]] | tuple[type[Any], type[Any]],
     ) -> _dlist.DistinctList[_MT_co]:
-        return _UpcastingDistinctList[
+        return ProxyDistinctList[
             type_args[0],  # type: ignore [valid-type]
             type_args[1],  # type: ignore [valid-type]
         ]  # type: ignore [return-value]
@@ -843,13 +637,12 @@ class _MultiLinkWithProps(
         cls,
         value: Any,
         generic_args: tuple[type[Any], type[Any]],
-    ) -> _UpcastingDistinctList[_PT_co, _BMT_co]:
-        lt: type[_UpcastingDistinctList[_PT_co, _BMT_co]] = (
-            _UpcastingDistinctList[
-                generic_args[0],  # type: ignore [valid-type]
-                generic_args[1],  # type: ignore [valid-type]
-            ]
-        )
+    ) -> ProxyDistinctList[_PT_co, _BMT_co]:
+        lt: type[ProxyDistinctList[_PT_co, _BMT_co]] = ProxyDistinctList[
+            generic_args[0],  # type: ignore [valid-type]
+            generic_args[1],  # type: ignore [valid-type]
+        ]
+
         if type(lt) is list:  # type: ignore [comparison-overlap]
             # Optimization for the most common scenario - user passes
             # a list of objects to the constructor.

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -643,7 +643,7 @@ class _MultiLinkWithProps(
             generic_args[1],  # type: ignore [valid-type]
         ]
 
-        if type(lt) is list:  # type: ignore [comparison-overlap]
+        if type(value) is list:
             # Optimization for the most common scenario - user passes
             # a list of objects to the constructor.
             return lt(value)

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -401,7 +401,7 @@ class _AnyLink(Generic[_MT_co, _BMT_co]):
         if value is None or isinstance(value, mt):
             return value
         elif isinstance(value, bmt):
-            return mt(value)  # type: ignore [no-any-return]
+            return mt.link(value)  # type: ignore [no-any-return]
         else:
             raise TypeError(
                 f"could not convert {type(value)} to {mt.__name__}"
@@ -437,7 +437,7 @@ class _Link(
         if isinstance(value, mt):
             return value  # type: ignore [no-any-return]
         elif isinstance(value, bmt):
-            return mt(value)  # type: ignore [no-any-return]
+            return mt.link(value)  # type: ignore [no-any-return]
         else:
             raise TypeError(
                 f"could not convert {type(value)} to {mt.__name__}"

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -804,13 +804,6 @@ class _MultiLink(
             )
 
 
-@functools.cache
-def _make_dlist_type(
-    types: tuple[type[_PT_co], type[_BMT_co]],
-) -> type[_UpcastingDistinctList[_PT_co, _BMT_co]]:
-    return _UpcastingDistinctList[types[0], types[1]]  # type: ignore [valid-type]
-
-
 class _MultiLinkWithProps(
     _MultiPointer[_PT_co, _BMT_co],
     _abstract.LinkDescriptor[_PT_co, _BMT_co],
@@ -840,7 +833,10 @@ class _MultiLinkWithProps(
         cls,
         type_args: tuple[type[Any]] | tuple[type[Any], type[Any]],
     ) -> _dlist.DistinctList[_MT_co]:
-        return _make_dlist_type(type_args)  # type: ignore [return-value]
+        return _UpcastingDistinctList[
+            type_args[0],  # type: ignore [valid-type]
+            type_args[1],  # type: ignore [valid-type]
+        ]  # type: ignore [return-value]
 
     @classmethod
     def _validate(
@@ -848,8 +844,11 @@ class _MultiLinkWithProps(
         value: Any,
         generic_args: tuple[type[Any], type[Any]],
     ) -> _UpcastingDistinctList[_PT_co, _BMT_co]:
-        lt: type[_UpcastingDistinctList[_PT_co, _BMT_co]] = _make_dlist_type(
-            generic_args
+        lt: type[_UpcastingDistinctList[_PT_co, _BMT_co]] = (
+            _UpcastingDistinctList[
+                generic_args[0],  # type: ignore [valid-type]
+                generic_args[1],  # type: ignore [valid-type]
+            ]
         )
         if type(lt) is list:  # type: ignore [comparison-overlap]
             # Optimization for the most common scenario - user passes

--- a/gel/_internal/_qbmodel/_pydantic/_pdlist.py
+++ b/gel/_internal/_qbmodel/_pydantic/_pdlist.py
@@ -1,0 +1,234 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+from typing import (
+    TYPE_CHECKING,
+    cast,
+    Any,
+    Generic,
+    SupportsIndex,
+    TypeVar,
+)
+
+from collections.abc import Iterable
+
+from typing_extensions import (
+    Self,
+)
+
+from gel._internal import _dlist
+
+from ._models import GelModel, ProxyModel
+
+from gel._internal._unsetid import UNSET_UUID
+
+
+_BMT_co = TypeVar("_BMT_co", bound=GelModel, covariant=True)
+"""Base model type"""
+
+_PT_co = TypeVar("_PT_co", bound=ProxyModel[GelModel], covariant=True)
+"""Proxy model"""
+
+
+ll_getattr = object.__getattribute__
+
+
+class ProxyDistinctList(_dlist.DistinctList[_PT_co], Generic[_PT_co, _BMT_co]):
+    # Mapping of object IDs to ProxyModels that wrap them.
+    _wrapped_index: dict[int, _PT_co] | None = None
+
+    def _init_tracking(self) -> None:
+        super()._init_tracking()
+
+        if self._wrapped_index is None:
+            self._wrapped_index = {}
+            for item in self._items:
+                assert isinstance(item, ProxyModel)
+                wrapped = ll_getattr(item, "_p__obj__")
+                self._wrapped_index[id(wrapped)] = cast("_PT_co", item)
+
+    def _track_item(self, item: _PT_co) -> None:  # type: ignore [misc]
+        assert isinstance(item, ProxyModel)
+        super()._track_item(cast("_PT_co", item))
+        assert self._wrapped_index is not None
+        wrapped = ll_getattr(item, "_p__obj__")
+        self._wrapped_index[id(wrapped)] = cast("_PT_co", item)
+
+    def _untrack_item(self, item: _PT_co) -> None:  # type: ignore [misc]
+        assert isinstance(item, ProxyModel)
+        super()._untrack_item(cast("_PT_co", item))
+        assert self._wrapped_index is not None
+        wrapped = ll_getattr(item, "_p__obj__")
+        self._wrapped_index.pop(id(wrapped), None)
+
+    def _is_tracked(self, item: _PT_co | _BMT_co) -> bool:
+        self._init_tracking()
+        assert self._wrapped_index is not None
+
+        if isinstance(item, ProxyModel):
+            return id(item._p__obj__) in self._wrapped_index
+        else:
+            return id(item) in self._wrapped_index
+
+    def extend(self, values: Iterable[_PT_co | _BMT_co]) -> None:
+        # An optimized version of `extend()`
+
+        if not values:
+            # Empty list => early return
+            return
+
+        if values is self:
+            values = list(values)
+
+        self._ensure_snapshot()
+
+        cls = type(self)
+        t = cls.type
+
+        assert self._wrapped_index is not None
+        assert self._set is not None
+        assert self._unhashables is not None
+
+        # For an empty list we can call one extend() call instead
+        # of slow iterative appends.
+        fast_extend = len(self._wrapped_index) == 0
+
+        for v in values:
+            tv = type(v)
+            if tv is t.__proxy_of__:
+                # Fast path -- `v` is an instance of the base type.
+                # It has no link props, wrap it in a proxy in
+                # a fast way.
+                proxy = t.__gel_proxy_construct__(v, {})
+                obj = v
+            elif tv is t:
+                # Another fast path -- `v` is already the correct proxy.
+                proxy = v  # type: ignore [assignment]
+                obj = ll_getattr(v, "_p__obj__")
+            else:
+                proxy, obj = self._cast_value(v)
+
+            oid = id(obj)
+            existing_proxy = self._wrapped_index.get(oid)
+            if existing_proxy is None:
+                self._wrapped_index[oid] = proxy
+            else:
+                if (
+                    existing_proxy.__linkprops__.__dict__
+                    != proxy.__linkprops__.__dict__
+                ):
+                    raise ValueError(
+                        f"the list already contains {v!r} with "
+                        f"a different set of link properties"
+                    )
+
+            if obj.id is UNSET_UUID:
+                self._unhashables[id(proxy)] = proxy
+            else:
+                self._set.add(proxy)
+
+            if not fast_extend:
+                self._items.append(proxy)
+
+        if fast_extend:
+            self._items.extend(self._wrapped_index.values())
+
+    def _cast_value(self, value: Any) -> tuple[_PT_co, _BMT_co]:
+        cls = type(self)
+        t = cls.type
+
+        assert issubclass(t, ProxyModel)
+
+        tp_value = type(value)
+
+        if tp_value is t.__proxy_of__:
+            # Fast path before we make all expensive isinstance calls.
+            return (
+                t.__gel_proxy_construct__(value, {}),
+                value,
+            )  # type: ignore [return-value]
+
+        if tp_value is t:
+            # It's a correct proxy for this link... return as is.
+            return (
+                value,
+                ll_getattr(value, "_p__obj__"),
+            )
+
+        if not isinstance(value, ProxyModel) and isinstance(
+            value, t.__proxy_of__
+        ):
+            # It's not a proxy, but the object is of the correct type --
+            # re-wrap it in a correct proxy.
+            return (
+                t.__gel_proxy_construct__(value, {}),
+                value,
+            )  # type: ignore [return-value]
+
+        raise ValueError(
+            f"{cls!r} accepts only values of type {t.__name__} "
+            f"or {t.__proxy_of__.__name__}, got {tp_value!r}",
+        )
+
+    def _check_value(self, value: Any) -> _PT_co:
+        proxy, obj = self._cast_value(value)
+
+        # We have to check if a proxy around the same object is already
+        # present in the list.
+        self._init_tracking()
+        assert self._wrapped_index is not None
+        try:
+            existing_proxy = self._wrapped_index[id(obj)]
+        except KeyError:
+            return proxy
+
+        assert isinstance(existing_proxy, ProxyModel)
+
+        if (
+            existing_proxy.__linkprops__.__dict__
+            != proxy.__linkprops__.__dict__
+        ):
+            raise ValueError(
+                f"the list already contains {value!r} with "
+                f" a different set of link properties"
+            )
+        # Return the already present identical proxy instead of inserting
+        # another one
+        return existing_proxy  # type: ignore [return-value]
+
+    def _find_proxied_obj(self, item: _PT_co | _BMT_co) -> _PT_co | None:
+        self._init_tracking()
+        assert self._wrapped_index is not None
+
+        if isinstance(item, ProxyModel):
+            item = item._p__obj__
+
+        return self._wrapped_index.get(id(item), None)
+
+    def clear(self) -> None:
+        super().clear()
+        self._wrapped_index = None
+
+    if TYPE_CHECKING:
+
+        def append(self, value: _PT_co | _BMT_co) -> None: ...
+        def insert(
+            self, index: SupportsIndex, value: _PT_co | _BMT_co
+        ) -> None: ...
+        def __setitem__(
+            self,
+            index: SupportsIndex | slice,
+            value: _PT_co | _BMT_co | Iterable[_PT_co | _BMT_co],
+        ) -> None: ...
+        def extend(self, values: Iterable[_PT_co | _BMT_co]) -> None: ...
+        def remove(self, value: _PT_co | _BMT_co) -> None: ...
+        def index(
+            self,
+            value: _PT_co | _BMT_co,
+            start: SupportsIndex = 0,
+            stop: SupportsIndex | None = None,
+        ) -> int: ...
+        def count(self, value: _PT_co | _BMT_co) -> int: ...
+        def __add__(self, other: Iterable[_PT_co | _BMT_co]) -> Self: ...
+        def __iadd__(self, other: Iterable[_PT_co | _BMT_co]) -> Self: ...

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -28,7 +28,7 @@ from gel._internal._dlist import (
 )
 from gel._internal._unsetid import UNSET_UUID
 from gel._internal._edgeql import PointerKind, quote_ident
-from gel._internal._qbmodel._pydantic._fields import _UpcastingDistinctList
+from gel._internal._qbmodel._pydantic._pdlist import ProxyDistinctList
 
 if TYPE_CHECKING:
     import uuid
@@ -255,8 +255,8 @@ def is_link_list(val: object) -> TypeGuard[DistinctList[GelModel]]:
 
 def is_proxy_link_list(
     val: object,
-) -> TypeGuard[_UpcastingDistinctList[ProxyModel[GelModel], GelModel]]:
-    return isinstance(val, _UpcastingDistinctList)
+) -> TypeGuard[ProxyDistinctList[ProxyModel[GelModel], GelModel]]:
+    return isinstance(val, ProxyDistinctList)
 
 
 def unwrap_proxy(val: GelModel) -> GelModel:
@@ -626,7 +626,7 @@ def make_plan(objs: Iterable[GelModel]) -> SavePlan:
             #
             # First, we iterate through the list of added new objects
             # to the list. All of them should be ProxyModels
-            # (as we use UpcastingDistinctList for links with props.)
+            # (as we use ProxyDistinctList for links with props.)
             # Our goal is to segregate different combinations of
             # set link properties into separate groups.
             link_tp = type(added_proxies[0])

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import contextlib
 import collections
+import dataclasses
 import datetime
 import queue
 import socket
@@ -50,6 +51,24 @@ MINIMUM_PING_WAIT_TIME = datetime.timedelta(seconds=1)
 
 
 T = typing.TypeVar("T")
+
+
+@dataclasses.dataclass
+class SaveDebug:
+    queries: list[SaveQueryDebug]
+    plan_time: float
+
+
+@dataclasses.dataclass
+class SaveQueryDebug:
+    query: str = ""
+    max_args_number: int = 0
+    total_execs: int = 0
+    total_exec_time: float = 0
+    analyze: str = ""
+    analyze_args: object = None
+    args_query: str = ""
+    args_analyze: object = None
 
 
 def iter_coroutine(coro: typing.Coroutine[None, None, T]) -> T:
@@ -560,14 +579,12 @@ class Client(base_client.BaseClient, abstract.Executor):
 
                 executor.commit()
 
-    def __debug_save__(self, *objs: GelModel) -> dict[str, float]:
-        timings = collections.defaultdict(float)
-        nqueries = collections.defaultdict(int)
-
+    def __debug_save__(self, *objs: GelModel) -> SaveDebug:
         ns = time.monotonic_ns()
         make_executor = make_save_executor_constructor(objs)
-        timings["__create_plan__"] = time.monotonic_ns() - ns
-        nqueries["__create_plan__"] = 1
+        plan_time = time.monotonic_ns() - ns
+
+        queries = collections.defaultdict(SaveQueryDebug)
 
         for tx in self._batch():
             with tx:
@@ -575,19 +592,41 @@ class Client(base_client.BaseClient, abstract.Executor):
 
                 for batches in executor:
                     for batch in batches:
+                        qdebug = queries[batch.query]
+
+                        qdebug.total_execs += 1
+                        qdebug.query = batch.query
+                        qdebug.args_query = batch.args_query
+
+                        if not qdebug.analyze:
+                            tx.send_query(f"ANALYZE {batch.query}", batch.args)
+                            qdebug.analyze = tx.wait()[0][0]
+                            tx.send_query(
+                                f"ANALYZE {batch.args_query}", batch.args
+                            )
+                            qdebug.args_analyze = tx.wait()[0][0]
+                            qdebug.analyze_args = batch.args
+
                         ns = time.monotonic_ns()
                         tx.send_query(batch.query, batch.args)
                         batch_ids = tx.wait()
-                        timings[batch.query] += time.monotonic_ns() - ns
-                        nqueries[batch.query] += 1
+                        qdebug.total_exec_time += time.monotonic_ns() - ns
+
+                        qdebug.max_args_number = max(
+                            qdebug.max_args_number, len(batch.args)
+                        )
+
                         batch.feed_ids(batch_ids[0])
 
                 executor.commit()
 
-        return {
-            k: (v / 1_000_000.0, nqueries[k])
-            for k, v in sorted(timings.items(), key=lambda kv: kv[1])
-        }
+        for qdebug in queries.values():
+            qdebug.total_exec_time /= 1_000_000.0
+
+        return SaveDebug(
+            queries=sorted(queries.values(), key=lambda q: q.total_exec_time),
+            plan_time=plan_time / 1_000_000.0,
+        )
 
     def _query(self, query_context: abstract.QueryContext):
         return iter_coroutine(super()._query(query_context))

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -490,13 +490,15 @@ class TestModelGenerator(tb.ModelTestCase):
 
         # Let's test computed link as an arg
         with self.assertRaisesRegex(
-            ValueError, r"(?s)cannot set field .groups. on User"
+            ValueError,
+            r"(?s)User model does not accept .groups.*computed field",
         ):
             default.User(name="aaaa", groups=(1, 2, 3))  # type: ignore
 
         # Let's test computed property as an arg
         with self.assertRaisesRegex(
-            ValueError, r"(?s)cannot set field .name_len. on User"
+            ValueError,
+            r"(?s)User model does not accept .name_len.*computed field",
         ):
             default.User(name="aaaa", name_len=123)  # type: ignore
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -34,8 +34,8 @@ from gel._internal._reflection import SchemaPath
 from gel._internal._qbmodel._pydantic._models import GelModel
 from gel._internal._dlist import DistinctList
 from gel._internal._edgeql import Cardinality, PointerKind
-from gel._internal._qbmodel._pydantic._fields import (
-    _UpcastingDistinctList,
+from gel._internal._qbmodel._pydantic._pdlist import (
+    ProxyDistinctList,
 )
 
 
@@ -116,18 +116,18 @@ class TestModelGenerator(tb.ModelTestCase):
                             f"type is {e.type!r}",
                         )
 
-                if issubclass(p.type, _UpcastingDistinctList):
-                    if not issubclass(e.type, _UpcastingDistinctList):
+                if issubclass(p.type, ProxyDistinctList):
+                    if not issubclass(e.type, ProxyDistinctList):
                         self.fail(
                             f"{obj.__name__}.{p.name} eq_type check "
-                            f" failed: p.type is _UpcastingDistinctList, "
+                            f" failed: p.type is ProxyDistinctList, "
                             f"but expected type is {e.type!r}",
                         )
                 else:
-                    if issubclass(e.type, _UpcastingDistinctList):
+                    if issubclass(e.type, ProxyDistinctList):
                         self.fail(
                             f"{obj.__name__}.{p.name} eq_type check failed: "
-                            f"p.type is not a _UpcastingDistinctList, but "
+                            f"p.type is not a ProxyDistinctList, but "
                             f"expected type is {e.type!r}",
                         )
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -417,7 +417,7 @@ class TestModelGenerator(tb.ModelTestCase):
         with self.assertRaisesRegex(
             ValueError, r"(?s)only instances of User are allowed, got .*int"
         ):
-            default.GameSession.players(1)  # type: ignore
+            default.GameSession.players.link(1)  # type: ignore
 
         u = default.User(name="batman")
         p = default.Post(body="aaa", author=u)
@@ -425,6 +425,14 @@ class TestModelGenerator(tb.ModelTestCase):
             ValueError, r"(?s)prayers.*Extra inputs are not permitted"
         ):
             default.GameSession(num=7, prayers=[p])  # type: ignore
+
+        gp = default.GameSession.players(name="johny")
+        self.assertIsInstance(gp, default.User)
+        self.assertIsInstance(gp, default.GameSession.players)
+        self.assertIsInstance(gp._p__obj__, default.User)
+        self.assertEqual(gp.name, "johny")
+        self.assertEqual(gp._p__obj__.name, "johny")
+        self.assertIsNotNone(gp.__linkprops__)
 
         # Check that `groups` is not an allowed keyword-arg for `User.__init__`
         self.assertEqual(


### PR DESCRIPTION
* `save()` now calls `__gel_commit__()` on link props of single links.
* `ProxyModel.__init__()` has now correct signature and behavior (it was the same as `ProxyModel.link()`
* Massive speedups -- `ProxyModel.link()` is 3x faster, the overhead of link properties on model creation is now low enough to not worry about much
* `save()` generates more efficient queries -- 2x speedup for saving link properties