### PR TITLE
batch: consider the error of wait() on __exit__

### DIFF
--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -536,6 +536,8 @@ class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
     def _batch(self) -> AsyncIOBatch:
         return AsyncIOBatch(
             self.with_config(
+                # We only need to disable transaction idle timeout;
+                # session idle timeouts can't interrupt transactions.
                 session_idle_transaction_timeout=datetime.timedelta()
             )
         )

--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -23,6 +23,7 @@ from typing_extensions import Self
 
 import asyncio
 import contextlib
+import datetime
 import logging
 import socket
 import ssl
@@ -533,7 +534,11 @@ class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
         return AsyncIORetry(self)
 
     def _batch(self) -> AsyncIOBatch:
-        return AsyncIOBatch(self)
+        return AsyncIOBatch(
+            self.with_config(
+                session_idle_transaction_timeout=datetime.timedelta()
+            )
+        )
 
     async def save(self, *objs: GelModel) -> None:
         make_executor = make_save_executor_constructor(objs)

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -662,6 +662,8 @@ class Client(base_client.BaseClient, abstract.Executor):
     def _batch(self) -> Batch:
         return Batch(
             self.with_config(
+                # We only need to disable transaction idle timeout;
+                # session idle timeouts can't interrupt transactions.
                 session_idle_transaction_timeout=datetime.timedelta()
             )
         )

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -17,8 +17,6 @@
 #
 
 from __future__ import annotations
-
-from __future__ import annotations
 from typing import Any
 
 import contextlib
@@ -422,7 +420,15 @@ class BatchIteration(transaction.BaseTransaction):
 
     def __exit__(self, extype, ex, tb):
         with self._exclusive():
-            iter_coroutine(self._wait())
+            if extype is None:
+                try:
+                    iter_coroutine(self._wait())
+                except Exception as ex:
+                    self._managed = False
+                    if iter_coroutine(self._exit(type(ex), ex)):
+                        return True
+                    else:
+                        raise
             self._managed = False
             return iter_coroutine(self._exit(extype, ex))
 

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -660,7 +660,11 @@ class Client(base_client.BaseClient, abstract.Executor):
         return Retry(self)
 
     def _batch(self) -> Batch:
-        return Batch(self)
+        return Batch(
+            self.with_config(
+                session_idle_transaction_timeout=datetime.timedelta()
+            )
+        )
 
     def close(self, timeout=None):
         """Attempt to gracefully close all connections in the client.

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1332,3 +1332,13 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
                 await bx.send_query_single('SELECT <test::MyType2>$0', 42)
                 await bx.send_query_single('SELECT <test::MyType3>$0', 42)
                 self.assertEqual(await bx.wait(), [42, 42, 42])
+
+    async def test_batch_07(self):
+        c = self.client.with_config(session_idle_transaction_timeout=0.2)
+        async for bx in c._batch():
+            async with bx:
+                await bx.send_query_single("select 42")
+                self.assertEqual(await bx.wait(), [42])
+                await asyncio.sleep(0.6)
+                await bx.send_query_single("select 42")
+                self.assertEqual(await bx.wait(), [42])

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -1162,3 +1162,13 @@ class TestSyncQuery(tb.SyncQueryTestCase):
                 bx.send_query_single('SELECT <test::MyType2>$0', 42)
                 bx.send_query_single('SELECT <test::MyType3>$0', 42)
                 self.assertEqual(bx.wait(), [42, 42, 42])
+
+    def test_batch_07(self):
+        c = self.client.with_config(session_idle_transaction_timeout=0.2)
+        for bx in c._batch():
+            with bx:
+                bx.send_query_single("select 42")
+                self.assertEqual(bx.wait(), [42])
+                time.sleep(0.6)
+                bx.send_query_single("select 42")
+                self.assertEqual(bx.wait(), [42])


### PR DESCRIPTION
* Don't automatically `wait()` on `__exit__` if there was an error already
* The automatic `wait()` can now trigger retry too
* Also, disable `session_idle_transaction_timeout` when running batch