### PR TITLE
models: Rework the import code generation

### DIFF
--- a/gel/_internal/_codegen/_module.py
+++ b/gel/_internal/_codegen/_module.py
@@ -6,21 +6,24 @@
 from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
-    TypeAlias,
 )
 
 import collections
 import collections.abc
 import contextlib
+import dataclasses
 import enum
+import operator
 import re
 import textwrap
 from collections import defaultdict
 
+from gel._internal._polyfills._intenum import IntEnum
+
 if TYPE_CHECKING:
     import io
 
-    from collections.abc import Iterator, Iterable, Mapping
+    from collections.abc import Iterator, Iterable
     from collections.abc import Set as AbstractSet
 
 
@@ -28,21 +31,17 @@ MAX_LINE_LENGTH = 79
 
 
 class _ImportSource(enum.Enum):
-    local = enum.auto()
-    lib = enum.auto()
     std = enum.auto()
+    lib = enum.auto()
+    local = enum.auto()
 
 
-class ImportTime(enum.Enum):
-    runtime = enum.auto()
-    late_runtime = enum.auto()
+class ImportTime(IntEnum):
     typecheck = enum.auto()
     typecheck_runtime = enum.auto()
-
-
-class _ImportKind(enum.Enum):
-    names = enum.auto()
-    self = enum.auto()
+    late_runtime = enum.auto()
+    runtime = enum.auto()
+    local = enum.auto()
 
 
 class CodeSection(enum.Enum):
@@ -50,14 +49,192 @@ class CodeSection(enum.Enum):
     after_late_import = enum.auto()
 
 
-_Imports: TypeAlias = defaultdict[
-    _ImportSource,
-    defaultdict[_ImportKind, defaultdict[str, set[str]]],
-]
+def _disambiguate_name(
+    name: str,
+    globalns: AbstractSet[str],
+    localns: AbstractSet[str] | None = None,
+) -> str:
+    if not _in_ns(name, globalns) and not _in_ns(name, localns):
+        return name
+
+    ctr = 0
+
+    def _mangle(name: str) -> str:
+        nonlocal ctr
+        if ctr == 0:
+            return f"{name}_"
+        else:
+            return f"{name}_{ctr}"
+
+    mangled = _mangle(name)
+    while _in_ns(mangled, globalns) or _in_ns(mangled, localns):
+        ctr += 1
+        mangled = _mangle(name)
+
+    return mangled
 
 
-def _new_imports_map() -> _Imports:
-    return defaultdict(lambda: defaultdict(lambda: defaultdict(set)))
+@dataclasses.dataclass(kw_only=True)
+class Import:
+    module: str
+    attr: str | None = None
+    alias: str | None = None
+    time: ImportTime
+    ref_attrs: set[str] = dataclasses.field(default_factory=set)
+    extra_aliases: set[str] = dataclasses.field(default_factory=set)
+
+    @property
+    def name(self) -> str:
+        return self.alias or self.attr or self.module.rpartition(".")[-1]
+
+    def non_conflicting_name(self, ns: AbstractSet[str] | None = None) -> str:
+        name = self.name
+        if ns is None:
+            return name
+        else:
+            alias = _disambiguate_name(name, ns)
+            if alias != name:
+                self.extra_aliases.add(alias)
+            return alias
+
+    @property
+    def source(self) -> _ImportSource:
+        module = self.module
+        if module == "gel" or module.startswith("gel."):
+            source = _ImportSource.lib
+        elif module.startswith("."):
+            source = _ImportSource.local
+        else:
+            source = _ImportSource.std
+
+        return source
+
+
+class _ImportScope:
+    imports: dict[ImportTime, dict[tuple[str, str | None], Import]]
+    ns: set[str]
+
+    def __init__(
+        self, namespace: set[str], parent: _ImportScope | None = None
+    ) -> None:
+        self.imports = {
+            ImportTime.typecheck: {},
+            ImportTime.typecheck_runtime: {},
+            ImportTime.runtime: {},
+            ImportTime.late_runtime: {},
+        }
+        self.ns = namespace
+        self.parent = parent
+
+    def get(self, import_time: ImportTime) -> Iterable[Import]:
+        return self.imports[import_time].values()
+
+    def _maybe_make_visible(
+        self,
+        module: str,
+        name: str | None,
+        import_time: ImportTime,
+    ) -> Import | None:
+        key = (module, name)
+        for imported_at, imports in self.imports.items():
+            if (imported := imports.get(key)) is not None:
+                if import_time > imported_at:
+                    if import_time is ImportTime.late_runtime:
+                        continue
+                    # Promote import
+                    imported.time = import_time
+                    del imports[key]
+                    self.imports[import_time][key] = imported
+
+                return imported
+            if (
+                self.parent is not None
+                and import_time <= imported_at
+                and (imported := self.parent.imports[import_time].get(key))
+                is not None
+            ):
+                return imported
+
+        return None
+
+    def import_(
+        self,
+        module: str,
+        name: str | None,
+        *,
+        import_time: ImportTime = ImportTime.runtime,
+        always_import_qualified: bool = False,
+        suggested_module_alias: str | None = None,
+        localns: frozenset[str] | None = None,
+    ) -> str:
+        if _is_all_dots(module):
+            raise ValueError(
+                f"import_name: bare relative imports are "
+                f"not supported: {module!r}"
+            )
+
+        imported: Import | None = None
+        ref_expr: str | None = None
+        if name is not None and not always_import_qualified:
+            if imported := self._maybe_make_visible(module, name, import_time):
+                # Already imported
+                return imported.non_conflicting_name(localns)
+            if not _in_ns(name, self.ns) and not _in_ns(name, localns):
+                # No conflict with namespace
+                imported = Import(module=module, attr=name, time=import_time)
+                ref_expr = imported.name
+                if module == "builtins":
+                    # Avoid rendering needless `from builtins` imports
+                    return ref_expr
+
+        if imported is None:
+            # Module import (either direct or as a result of name conflict)
+            parent_module, dot, tail_module = module.rpartition(".")
+            if _is_all_dots(parent_module) or (not parent_module and dot):
+                # Pure relative import
+                parent_module += dot
+
+            submod: str | None
+            if parent_module:
+                module = parent_module
+                submod = tail_module
+            else:
+                submod = None
+
+            if imported := self._maybe_make_visible(
+                module, submod, import_time
+            ):
+                # Already imported
+                if name:
+                    imported.ref_attrs.add(name)
+                    return f"{imported.name}.{name}"
+                else:
+                    return imported.non_conflicting_name(localns)
+
+            import_name = submod or module
+            alias = _disambiguate_name(
+                suggested_module_alias or import_name,
+                globalns=self.ns,
+            )
+
+            imported = Import(
+                module=module,
+                attr=submod,
+                alias=alias if alias != import_name else None,
+                time=import_time,
+            )
+
+            if name:
+                imported.ref_attrs.add(name)
+                ref_expr = f"{imported.name}.{name}"
+            else:
+                ref_expr = imported.non_conflicting_name(localns)
+
+        self.imports[import_time][imported.module, imported.attr] = imported
+        self.ns.add(imported.name)
+
+        assert ref_expr is not None
+        return ref_expr
 
 
 def _is_all_dots(s: str) -> bool:
@@ -82,13 +259,11 @@ class GeneratedModule:
         self._content: defaultdict[CodeSection, list[str]] = defaultdict(list)
         self._code_section = CodeSection.main
         self._code = self._content[self._code_section]
-        self._imports: defaultdict[ImportTime, _Imports] = defaultdict(
-            _new_imports_map
-        )
-        self._substrate_module = substrate_module
         self._globals: set[str] = set()
         self._exports: set[str] = set()
+        self._imports = _ImportScope(self._globals)
         self._imported_names: dict[tuple[str, str, ImportTime], str] = {}
+        self._substrate_module = substrate_module
         self._typevars: defaultdict[str, dict[str | None, str]] = defaultdict(
             dict
         )
@@ -130,172 +305,37 @@ class GeneratedModule:
             self.add_global(typevar)
         return typevar
 
-    def _get_import_strings(
-        self,
-        module: str,
-        names: tuple[str, ...],
-        aliases: dict[str, str],
-    ) -> dict[_ImportKind, list[str]]:
-        all_names: list[str] = []
-        all_self_aliases: list[str] = []
-        for n in names:
-            if n == ".":
-                all_self_aliases.append("")
-            else:
-                all_names.append(n)
-
-        for k, v in aliases.items():
-            if v == ".":  # module import
-                all_self_aliases.append(k)
-            else:
-                all_names.append(f"{v} as {k}")
-
-        if not all_names and not all_self_aliases:
-            all_self_aliases.append("")
-
-        return {
-            _ImportKind.names: all_names,
-            _ImportKind.self: all_self_aliases,
-        }
-
-    def _get_import_source(self, module: str) -> _ImportSource:
-        if module == "gel" or module.startswith("gel."):
-            source = _ImportSource.lib
-        elif module.startswith("."):
-            source = _ImportSource.local
-        else:
-            source = _ImportSource.std
-
-        return source
-
-    def _update_import_maps(
-        self,
-        module: str,
-        names: tuple[str, ...],
-        aliases: dict[str, str],
-        *,
-        import_maps: _Imports,
-    ) -> None:
-        source = self._get_import_source(module)
-        import_lines = self._get_import_strings(module, names, aliases)
-        for import_kind, import_strings in import_lines.items():
-            import_maps[source][import_kind][module].update(import_strings)
-
     def disambiguate_name(self, name: str) -> str:
-        if name not in self._globals:
-            return name
-
-        ctr = 0
-
-        def _mangle(name: str) -> str:
-            nonlocal ctr
-            if ctr == 0:
-                return f"{name}_"
-            else:
-                return f"{name}_{ctr}"
-
-        mangled = _mangle(name)
-        while mangled in self._globals:
-            ctr += 1
-            mangled = _mangle(name)
-
-        return mangled
-
-    def _import_name(
-        self,
-        module: str,
-        name: str,
-        *,
-        suggested_module_alias: str | None = None,
-        import_maps: _Imports,
-        localns: frozenset[str] | None = None,
-    ) -> tuple[str, str]:
-        imported_names: tuple[str, ...] = ()
-        imported_aliases = {}
-        imported_module = module
-        if _is_all_dots(module):
-            raise ValueError(
-                f"import_name: bare relative imports are "
-                f"not supported: {module!r}"
-            )
-        if (
-            name != "."
-            and not _in_ns(name, self._globals)
-            and not _in_ns(name, localns)
-        ):
-            imported = name
-            new_global = imported
-            imported_names += (name,)
-        else:
-            parent_module, dot, tail_module = module.rpartition(".")
-            if _is_all_dots(parent_module) or (not parent_module and dot):
-                # Pure relative import
-                parent_module += dot
-
-            if parent_module:
-                imported_as = self.disambiguate_name(
-                    suggested_module_alias or tail_module
-                )
-                if imported_as == tail_module:
-                    imported_names += (imported_as,)
-                else:
-                    imported_aliases[imported_as] = tail_module
-                imported_module = parent_module
-            else:
-                imported_as = self.disambiguate_name(
-                    suggested_module_alias or module
-                )
-                imported_aliases[imported_as] = "."
-
-            new_global = imported_as
-            imported = imported_as if name == "." else f"{imported_as}.{name}"
-
-        self._update_import_maps(
-            imported_module,
-            imported_names,
-            imported_aliases,
-            import_maps=import_maps,
-        )
-        return imported, new_global
+        return _disambiguate_name(name, self._globals, None)
 
     def _do_import_name(
         self,
         module: str,
-        name: str,
+        name: str | None,
         *,
         suggested_module_alias: str | None = None,
+        always_import_qualified: bool = False,
         import_time: ImportTime = ImportTime.runtime,
         localns: frozenset[str] | None = None,
     ) -> str:
-        key = (module, name, import_time)
-        imported = self._imported_names.get(key)
-        cache_it = True
-        if imported is not None:
-            if not _in_ns(imported, localns):
-                return imported
-            else:
-                cache_it = False
+        if import_time is ImportTime.local:
+            scope = _ImportScope(set(), parent=self._imports)
+        else:
+            scope = self._imports
 
-        if import_time is ImportTime.late_runtime:
-            # See if there was a previous eager import for same name
-            early_key = (module, name, ImportTime.runtime)
-            imported = self._imported_names.get(early_key)
-            if imported is not None:
-                self._imported_names[key] = imported
-                return imported
-
-        imported, new_global = self._import_name(
+        imported = scope.import_(
             module,
             name,
             suggested_module_alias=suggested_module_alias,
-            import_maps=self._imports[import_time],
+            always_import_qualified=always_import_qualified,
+            import_time=ImportTime.runtime
+            if import_time is ImportTime.local
+            else import_time,
             localns=localns,
         )
 
-        self._globals.add(new_global)
-
-        if cache_it:
-            self._imported_names[key] = imported
+        if import_time is ImportTime.local:
+            self.write(self.render_imports(scope))
 
         return imported
 
@@ -306,51 +346,54 @@ class GeneratedModule:
         *,
         suggested_module_alias: str | None = None,
         import_time: ImportTime = ImportTime.runtime,
-        directly: bool = True,
         localns: frozenset[str] | None = None,
     ) -> str:
-        if directly:
-            if import_time is ImportTime.typecheck_runtime:
-                raise ValueError(
-                    "typecheck/deferred import time does not "
-                    "support direct name imports"
-                )
-            return self._do_import_name(
-                module,
-                name,
-                suggested_module_alias=suggested_module_alias,
-                import_time=import_time,
-                localns=localns,
+        if import_time is ImportTime.typecheck_runtime:
+            raise ValueError(
+                "typecheck/deferred import time does not "
+                "support direct name imports"
             )
-        else:
-            mod = self._do_import_name(
-                module,
-                ".",
-                suggested_module_alias=suggested_module_alias,
-                import_time=import_time,
-                localns=localns,
-            )
-            return f"{mod}.{name}"
+        return self._do_import_name(
+            module,
+            name,
+            suggested_module_alias=suggested_module_alias,
+            import_time=import_time,
+            localns=localns,
+        )
 
-    def render_name_import(
+    def import_qual_name(
         self,
         module: str,
         name: str,
         *,
         suggested_module_alias: str | None = None,
-    ) -> tuple[str, str]:
-        import_maps = _new_imports_map()
-        imported, _ = self._import_name(
+        import_time: ImportTime = ImportTime.runtime,
+        localns: frozenset[str] | None = None,
+    ) -> str:
+        return self._do_import_name(
             module,
             name,
             suggested_module_alias=suggested_module_alias,
-            import_maps=import_maps,
+            always_import_qualified=True,
+            import_time=import_time,
+            localns=localns,
         )
 
-        import_chunks = self._render_imports(import_maps)
-        import_code = "\n\n".join(import_chunks)
-
-        return imported, import_code
+    def import_module(
+        self,
+        module: str,
+        *,
+        suggested_module_alias: str | None = None,
+        import_time: ImportTime = ImportTime.runtime,
+        localns: frozenset[str] | None = None,
+    ) -> str:
+        return self._do_import_name(
+            module,
+            None,
+            suggested_module_alias=suggested_module_alias,
+            import_time=import_time,
+            localns=localns,
+        )
 
     def export(self, *names: str) -> None:
         self._exports.update(names)
@@ -477,68 +520,66 @@ class GeneratedModule:
         else:
             return ""
 
-    def render_imports(self) -> str:
-        tc_runtime = self._imports[ImportTime.typecheck_runtime]
-        typecheck_sections = self._render_imports(
-            self._imports[ImportTime.typecheck],
-            indent="    ",
-        ) + self._render_imports(tc_runtime, indent="    ")
+    def render_imports(self, scope: _ImportScope | None = None) -> str:
+        if scope is None:
+            scope = self._imports
 
-        tc = None
-        if any(typecheck_sections):
+        tc_imps = [*scope.get(ImportTime.typecheck)]
+        tc_runtime_imps = [*scope.get(ImportTime.typecheck_runtime)]
+        tc_sections = []
+
+        if tc_imps or tc_runtime_imps:
             tc = self.import_name("typing", "TYPE_CHECKING")
-        defimp = None
-        if self._has_imports(tc_runtime):
-            defimp = self.import_name(self._substrate_module, "DeferredImport")
-
-        sections = ["from __future__ import annotations"]
-        sections.extend(
-            self._render_imports(self._imports[ImportTime.runtime])
-        )
-
-        if any(typecheck_sections):
-            assert tc
-            sections.append(f"if {tc}:")
-            sections.extend(typecheck_sections)
-
-        if defimp is not None:
-            lazy_imports = self._render_deferred_imports(
-                tc_runtime, indent="    ", deferred_import=defimp
+            tc_sections.append(f"if {tc}:")
+            tc_sections.extend(
+                self._render_imports(tc_imps, indent=self.INDENT)
             )
-            if lazy_imports:
-                sections.append("else:")
-                sections.extend(lazy_imports)
+            if tc_runtime_imps:
+                tc_sections.extend(
+                    self._render_typecheck_faux_ns_imports(
+                        tc_runtime_imps,
+                        indent=self.INDENT,
+                    )
+                )
+                tc_sections.append("else:")
+                tc_sections.extend(
+                    self._render_deferred_imports(
+                        tc_runtime_imps,
+                        indent=self.INDENT,
+                        deferred_import=self.import_name(
+                            self._substrate_module, "DeferredImport"
+                        ),
+                    )
+                )
+
+        sections = (
+            self._render_imports(scope.get(ImportTime.runtime)) + tc_sections
+        )
 
         return "\n\n".join(filter(None, sections))
 
     def render_late_imports(self) -> str:
         sections = self._render_imports(
-            self._imports[ImportTime.late_runtime],
+            self._imports.get(ImportTime.late_runtime),
             noqa=["E402", "F403"],
         )
 
         return "\n\n".join(filter(None, sections))
 
-    def _has_imports(
-        self,
-        imports: _Imports,
-    ) -> bool:
-        return bool(imports) and any(
-            bool(sources) and any(sources.values())
-            for sources in imports.values()
-        )
-
     def _render_imports(
         self,
-        imports: _Imports,
+        imports: Iterable[Import],
         *,
         indent: str = "",
         noqa: list[str] | None = None,
     ) -> list[str]:
         blocks = []
+        by_source: defaultdict[_ImportSource, list[Import]] = defaultdict(list)
+        for imp in imports:
+            by_source[imp.source].append(imp)
         for source in _ImportSource.__members__.values():
             block = self._render_imports_source_block(
-                imports[source],
+                by_source[source],
                 indent=indent,
                 noqa=noqa,
             )
@@ -548,50 +589,73 @@ class GeneratedModule:
 
     def _render_imports_source_block(
         self,
-        imports: Mapping[_ImportKind, Mapping[str, set[str]]],
+        imports: list[Import],
         *,
         indent: str = "",
         noqa: list[str] | None = None,
     ) -> str:
         output = []
-        self_imports = imports[_ImportKind.self]
+        extra_aliases: list[str] = []
         mods = sorted(
-            self_imports.items(),
-            key=lambda kv: (len(kv[1]) == 0, kv[0]),
+            (imp for imp in imports if imp.attr is None),
+            key=lambda imp: imp.name,
         )
-        for modname, aliases in mods:
-            for alias in aliases:
-                if modname.startswith("."):
-                    match = re.match(r"^(\.+)(.*)", modname)
-                    assert match
-                    relative = match.group(1)
-                    rest = match.group(2)
-                    pkg, _, name = rest.rpartition(".")
-                    import_line = f"from {relative}{pkg} import {name}"
-                    if alias and alias != name:
-                        import_line += f" as {alias}"
-                elif alias:
-                    import_line = f"import {modname} as {alias}"
-                else:
-                    import_line = f"import {modname}"
-                if noqa:
-                    import_line += f"  # noqa: {' '.join(noqa)}"
-                output.append(import_line)
+        for imp in mods:
+            modname = imp.module
+            alias = imp.alias
+            if modname.startswith("."):
+                match = re.match(r"^(\.+)(.*)", modname)
+                assert match
+                relative = match.group(1)
+                rest = match.group(2)
+                pkg, _, name = rest.rpartition(".")
+                import_line = f"from {relative}{pkg} import {name}"
+                if alias and alias != name:
+                    import_line += f" as {alias}"
+            elif alias:
+                import_line = f"import {modname} as {alias}"
+            else:
+                import_line = f"import {modname}"
+            if noqa:
+                import_line += f"  # noqa: {' '.join(noqa)}"
+            output.append(import_line)
+            extra_aliases.extend(
+                f"{extra_alias} = {alias or modname}"
+                for extra_alias in sorted(imp.extra_aliases)
+            )
 
-        name_imports = imports[_ImportKind.names]
-        mods = sorted(
-            name_imports.items(),
-            key=lambda kv: (len(kv[1]) == 0, kv[0]),
-        )
+        import_lists: defaultdict[str, list[Import]] = defaultdict(list)
+        for imp in imports:
+            if imp.attr is not None:
+                import_lists[imp.module].append(imp)
 
         noqa_suf = f"  # noqa: {' '.join(noqa)}" if noqa else ""
 
-        for modname, names in mods:
+        name_imports = {
+            modname: sorted(
+                (imp for imp in names if imp.attr is not None),
+                key=lambda imp: (
+                    0
+                    if imp.name.isupper()
+                    else 1
+                    if imp.name[0].isupper()
+                    else 2,
+                    imp.name,
+                ),
+            )
+            for modname, names in import_lists.items()
+        }
+        for modname, names in sorted(
+            name_imports.items(), key=operator.itemgetter(0)
+        ):
             if not names:
                 continue
             import_line = f"from {modname} import "
-            names_list = list(names)
-            names_list.sort()
+            names_list = [
+                f"{imp.attr} as {imp.alias}" if imp.alias else imp.attr
+                for imp in names
+                if imp.attr is not None
+            ]
             names_part = ", ".join(names_list)
             if len(import_line) + len(names_part) > MAX_LINE_LENGTH:
                 import_line += (
@@ -600,23 +664,90 @@ class GeneratedModule:
             else:
                 import_line += names_part + noqa_suf
             output.append(import_line)
+            for imp in names:
+                extra_aliases.extend(
+                    f"{extra_alias} = {imp.name}"
+                    for extra_alias in sorted(imp.extra_aliases)
+                )
+
+        if extra_aliases:
+            output.extend(
+                [
+                    "",
+                    "# disambiguation for clashes in local namespaces",
+                    *extra_aliases,
+                ]
+            )
 
         result = "\n".join(output)
         if indent:
             result = textwrap.indent(result, indent)
         return result
 
+    def _render_typecheck_faux_ns_imports(
+        self,
+        imports: list[Import],
+        *,
+        indent: str = "",
+    ) -> list[str]:
+        output: list[str] = []
+        import_lists: defaultdict[str, list[Import]] = defaultdict(list)
+        for imp in imports:
+            if imp.ref_attrs:
+                import_lists[imp.name].append(imp)
+
+        name_imports = sorted(
+            import_lists.items(),
+            key=operator.itemgetter(0),
+        )
+
+        for modname, names in name_imports:
+            output.append(f"class {modname}:")
+            for imp in names:
+                if imp.attr is None:
+                    import_line = f"from {imp.module} import "
+                else:
+                    if _is_all_dots(imp.module):
+                        mod = f"{imp.module}{imp.attr}"
+                    else:
+                        mod = f"{imp.module}.{imp.attr}"
+                    import_line = f"from {mod} import "
+
+                ref_attrs = sorted(
+                    imp.ref_attrs,
+                    key=lambda s: (
+                        0 if s.isupper() else 1 if s[0].isupper() else 2,
+                        s,
+                    ),
+                )
+
+                nlist = [f"{s} as {s}" for s in ref_attrs]
+                names_part = ", ".join(nlist)
+                if len(import_line) + len(names_part) > MAX_LINE_LENGTH:
+                    import_line += "(\n    " + ",\n    ".join(nlist) + "\n)"
+                else:
+                    import_line += names_part
+                output.append(textwrap.indent(import_line, self.INDENT))
+
+        result = "\n".join(output)
+        if indent:
+            result = textwrap.indent(result, indent)
+        return [result]
+
     def _render_deferred_imports(
         self,
-        imports: _Imports,
+        imports: list[Import],
         *,
         indent: str = "",
         deferred_import: str,
     ) -> list[str]:
         blocks = []
+        by_source: defaultdict[_ImportSource, list[Import]] = defaultdict(list)
+        for imp in imports:
+            by_source[imp.source].append(imp)
         for source in _ImportSource.__members__.values():
             block = self._render_deferred_imports_source_block(
-                imports[source],
+                by_source[source],
                 indent=indent,
                 deferred_import=deferred_import,
             )
@@ -626,56 +757,57 @@ class GeneratedModule:
 
     def _render_deferred_imports_source_block(
         self,
-        imports: Mapping[_ImportKind, Mapping[str, set[str]]],
+        imports: list[Import],
         *,
         indent: str = "",
         deferred_import: str,
     ) -> str:
         output: list[str] = []
-        self_imports = imports[_ImportKind.self]
         mods = sorted(
-            self_imports.items(),
-            key=lambda kv: (len(kv[1]) == 0, kv[0]),
+            (imp for imp in imports if imp.attr is None),
+            key=lambda imp: imp.name,
         )
-
-        for modname, aliases in mods:
-            for maybe_alias in aliases:
-                if modname.startswith("."):
-                    match = re.match(r"^(\.+)(.*)", modname)
-                    assert match
-                    relative = match.group(1)
-                    rest = match.group(2)
-                    pkg, _, name = rest.rpartition(".")
-                    alias = maybe_alias or name
-                    import_line = (
-                        f"{alias} = {deferred_import}("
-                        f'"{relative}{pkg}", attr="{name}", '
-                        f'alias="{alias}", package=__package__)'
-                    )
-                else:
-                    alias = maybe_alias or modname
-                    import_line = (
-                        f"{alias} = {deferred_import}("
-                        f'"{modname}", alias="{alias}", package=__package__)'
-                    )
-                output.append(import_line)
-
-        name_imports = imports[_ImportKind.names]
-        mods = sorted(
-            name_imports.items(),
-            key=lambda kv: (len(kv[1]) == 0, kv[0]),
-        )
-
-        for modname, names in mods:
-            for imp_expr in names:
-                name, _, alias = imp_expr.partition(" as ")
-                if not alias:
-                    alias = name
-                output.append(
+        for imp in mods:
+            modname = imp.name
+            maybe_alias = imp.alias
+            if modname.startswith("."):
+                match = re.match(r"^(\.+)(.*)", modname)
+                assert match
+                relative = match.group(1)
+                rest = match.group(2)
+                pkg, _, name = rest.rpartition(".")
+                alias = maybe_alias or name
+                import_line = (
                     f"{alias} = {deferred_import}("
-                    f'"{modname}", attr="{name}", '
+                    f'"{relative}{pkg}", attr="{name}", '
                     f'alias="{alias}", package=__package__)'
                 )
+            else:
+                alias = maybe_alias or modname
+                import_line = (
+                    f"{alias} = {deferred_import}("
+                    f'"{modname}", alias="{alias}", package=__package__)'
+                )
+            output.append(import_line)
+
+        import_lists: defaultdict[str, list[Import]] = defaultdict(list)
+        for imp in imports:
+            if imp.attr is not None:
+                import_lists[imp.module].append(imp)
+
+        name_imports = sorted(
+            import_lists.items(),
+            key=lambda kv: (len(kv[1]) == 0, kv[0]),
+        )
+        output.extend(
+            (
+                f"{imp.name} = {deferred_import}("
+                f'"{imp.module}", attr="{imp.attr}", '
+                f'alias="{imp.name}", package=__package__)'
+            )
+            for _, names in name_imports
+            for imp in names
+        )
 
         result = "\n".join(output)
         if indent:
@@ -686,6 +818,7 @@ class GeneratedModule:
         typevars = self.render_typevars()
         out.write(self.get_comment_preamble())
         out.write("\n\n")
+        out.write("from __future__ import annotations\n\n")
         out.write(self.render_imports())
         if typevars:
             out.write("\n\n\n")

--- a/gel/_internal/_polyfills/_intenum.py
+++ b/gel/_internal/_polyfills/_intenum.py
@@ -1,0 +1,15 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+"""enum.IntEnum polyfill"""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import IntEnum
+else:
+    from ._intenum_impl import IntEnum
+
+
+__all__ = ("IntEnum",)

--- a/gel/_internal/_polyfills/_intenum_impl.py
+++ b/gel/_internal/_polyfills/_intenum_impl.py
@@ -1,0 +1,14 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+
+import enum as _enum
+
+
+class IntEnum(int, _enum.Enum):
+    __str__ = int.__str__
+    __format__ = int.__format__  # type: ignore [assignment]
+
+
+__all__ = ("IntEnum",)

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -4311,6 +4311,15 @@ class TestModelGenerator(tb.ModelTestCase):
         self.assertEqual(c, 1)
 
 
+class TestEmptyModelGenerator(tb.ModelTestCase):
+    DEFAULT_MODULE = "default"
+
+    @tb.typecheck
+    def test_modelgen_empty_schema_1(self):
+        # This is it, we're just testing empty import.
+        from models import default, std  # noqa: F401
+
+
 class TestEmptyAiModelGenerator(tb.ModelTestCase):
     DEFAULT_MODULE = "default"
     SCHEMA = os.path.join(os.path.dirname(__file__), "dbsetup", "empty_ai.gel")


### PR DESCRIPTION
Current import code generation is messy and buggy, generating
unnecessary imports and making it hard to implement non-trivial import
patterns.  Rewrite it and fix the high level API to clearly
differentiate between module and name imports.

With the above cleanups, extend `typecheck_runtime` import cycle
robustness to `TYPE_CHECKING` branches, as `mypy` seems unable to cope
with references to attributes in import-cycle imports (generating bogus
`name-defined` errors).  The approach is to import the names from the
module into a class namespace, e.g:

    if TYPE_CHECKING:
        class mymod_alias:
            from mymod import Foo

    else:
        mymod_alias = DeferredImport("mymod")

    mymod_alias.Foo  # works at runtime and at type-checking time
