### PR TITLE
Reimplement `SchemaPath`

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -351,7 +351,7 @@ class SchemaGenerator:
         part = self._schema_part
         std_modules: dict[SchemaPath, bool] = dict.fromkeys(
             (
-                SchemaPath.from_schema_name(mod)
+                SchemaPath(mod)
                 for mod in reflection.fetch_modules(self._client, part)
             ),
             False,
@@ -433,7 +433,7 @@ class SchemaGenerator:
 
     def introspect_schema(self) -> Schema:
         for mod in reflection.fetch_modules(self._client, self._schema_part):
-            self._modules[SchemaPath.from_schema_name(mod)] = {
+            self._modules[SchemaPath(mod)] = {
                 "scalar_types": {},
                 "object_types": {},
                 "functions": [],
@@ -460,7 +460,7 @@ class SchemaGenerator:
             self._operators = self._operators.chain(std_operators)
             self._functions = these_funcs + self._std_schema.functions
             self._std_modules = [
-                SchemaPath.from_schema_name(mod)
+                SchemaPath(mod)
                 for mod in reflection.fetch_modules(self._client, std_part)
             ]
         else:
@@ -566,7 +566,7 @@ def mod_filename(
         dirpath = modpath.parent
         filename = f"{modpath.name}.py"
 
-    return pathlib.Path(dirpath) / filename
+    return dirpath.as_pathlib_path() / filename
 
 
 def _map_name(
@@ -1355,7 +1355,7 @@ class BaseGeneratedModule:
 
         cur_aspect = self.current_aspect
         cache_key = (
-            type_path.as_schema_name(),
+            str(type_path),
             aspect,
             cur_aspect,
             False,
@@ -5188,7 +5188,7 @@ class GeneratedGlobalModule(BaseGeneratedModule):
         anytuple = self.import_name(BASE_IMPL, "AnyNamedTuple")
 
         self.write("#")
-        self.write(f"# tuple type {t.schemapath.as_schema_name()}")
+        self.write(f"# tuple type {t.schemapath}")
         self.write("#")
         classname = self.get_tuple_name(t)
         with self._class_def(f"_{classname}", [namedtuple]):

--- a/gel/_internal/_qb/_abstract.py
+++ b/gel/_internal/_qb/_abstract.py
@@ -16,10 +16,10 @@ import weakref
 from dataclasses import dataclass, field
 
 from gel._internal import _edgeql
-from gel._internal import _reflection
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping
+    from gel._internal._schemapath import SchemaPath
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -78,7 +78,7 @@ class Expr(Node):
     def precedence(self) -> _edgeql.Precedence: ...
 
     @abc.abstractproperty
-    def type(self) -> _reflection.SchemaPath: ...
+    def type(self) -> SchemaPath: ...
 
     @abc.abstractmethod
     def __edgeql_expr__(self, *, ctx: ScopeContext | None) -> str: ...
@@ -89,10 +89,10 @@ class Expr(Node):
 
 @dataclass(kw_only=True, frozen=True)
 class TypedExpr(Expr):
-    type_: _reflection.SchemaPath
+    type_: SchemaPath
 
     @property
-    def type(self) -> _reflection.SchemaPath:
+    def type(self) -> SchemaPath:
         return self.type_
 
 
@@ -453,7 +453,7 @@ class ImplicitIteratorStmt(IteratorExpr, Stmt):
     """Base class for statements that are implicit iterators"""
 
     @property
-    def type(self) -> _reflection.SchemaPath:
+    def type(self) -> SchemaPath:
         return self.iter_expr.type
 
     @property

--- a/gel/_internal/_qb/_expressions.py
+++ b/gel/_internal/_qb/_expressions.py
@@ -19,9 +19,8 @@ import weakref
 from dataclasses import dataclass, field
 
 from gel._internal import _edgeql
-from gel._internal import _reflection
 from gel._internal._polyfills import _strenum
-from gel._internal._reflection import SchemaPath
+from gel._internal._schemapath import SchemaPath
 
 from ._abstract import (
     AtomicExpr,
@@ -87,7 +86,7 @@ class Variable(Symbol):
 
 @dataclass(kw_only=True, frozen=True)
 class SchemaSet(IdentLikeExpr):
-    type_: _reflection.SchemaPath
+    type_: SchemaPath
 
     def __edgeql_expr__(self, *, ctx: ScopeContext | None) -> str:
         return "::".join(self.type.parts)
@@ -292,13 +291,11 @@ class CastOp(PrefixOp):
         return f"<{self.type.as_quoted_schema_name()}>{expr}"
 
 
-def empty_set(type_: _reflection.SchemaPath) -> CastOp:
+def empty_set(type_: SchemaPath) -> CastOp:
     return CastOp(expr=SetLiteral(items=(), type_=type_), type_=type_)
 
 
-def empty_set_if_none(
-    val: _T | None, type_: _reflection.SchemaPath
-) -> _T | CastOp:
+def empty_set_if_none(val: _T | None, type_: SchemaPath) -> _T | CastOp:
     return empty_set(type_) if val is None else val
 
 
@@ -483,7 +480,7 @@ class OrderByElem(Expr):
         return (self.expr,)
 
     @property
-    def type(self) -> _reflection.SchemaPath:
+    def type(self) -> SchemaPath:
         return self.expr.type
 
     @property
@@ -729,7 +726,7 @@ class ForStmt(IteratorExpr):
         object.__setattr__(self, "var", var)
 
     @property
-    def type(self) -> _reflection.SchemaPath:
+    def type(self) -> SchemaPath:
         return self.body.type
 
     def subnodes(self) -> Iterable[Node]:
@@ -751,7 +748,7 @@ class Splat(_strenum.StrEnum):
 @dataclass(kw_only=True, frozen=True)
 class ShapeElement(Node):
     name: str | Splat
-    origin: _reflection.SchemaPath
+    origin: SchemaPath
     expr: Expr | None = None
 
     def subnodes(self) -> Iterable[Node]:
@@ -763,7 +760,7 @@ class ShapeElement(Node):
     @classmethod
     def splat(
         cls,
-        source: _reflection.SchemaPath,
+        source: SchemaPath,
         *,
         kind: Splat = Splat.STAR,
     ) -> Self:
@@ -780,7 +777,7 @@ class Shape(Node):
     @classmethod
     def splat(
         cls,
-        source: _reflection.SchemaPath,
+        source: SchemaPath,
         *,
         kind: Splat = Splat.STAR,
     ) -> Self:
@@ -838,7 +835,7 @@ class ShapeOp(IteratorExpr):
         return (self.iter_expr, self.shape)
 
     @property
-    def type(self) -> _reflection.SchemaPath:
+    def type(self) -> SchemaPath:
         return self.iter_expr.type
 
     @property

--- a/gel/_internal/_qb/_expressions.py
+++ b/gel/_internal/_qb/_expressions.py
@@ -562,7 +562,7 @@ class InsertStmt(Stmt, TypedExpr):
         return (self.shape,)
 
     def _edgeql(self, ctx: ScopeContext) -> str:
-        text = f"{self.stmt} {self.type.as_schema_name()}"
+        text = f"{self.stmt} {self.type.as_quoted_schema_name()}"
         if self.shape is not None:
             source = SchemaSet(type_=self.type)
             text = f"{text} {_render_shape(self.shape, source, ctx)}"

--- a/gel/_internal/_qb/_generics.py
+++ b/gel/_internal/_qb/_generics.py
@@ -42,7 +42,7 @@ from ._reflection import GelTypeMetadata
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from gel._internal._reflection import SchemaPath
+    from gel._internal._schemapath import SchemaPath
     from ._abstract import Expr
 
 

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -10,13 +10,13 @@ import dataclasses
 if TYPE_CHECKING:
     import uuid
     from gel._internal import _edgeql
-    from gel._internal import _reflection
+    from gel._internal._schemapath import SchemaPath
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GelPointerReflection:
     name: str
-    type: _reflection.SchemaPath
+    type: SchemaPath
     typexpr: str
     kind: _edgeql.PointerKind
     cardinality: _edgeql.Cardinality
@@ -28,13 +28,13 @@ class GelPointerReflection:
 
 class GelReflectionProto(Protocol):
     id: ClassVar[uuid.UUID]
-    name: ClassVar[_reflection.SchemaPath]
+    name: ClassVar[SchemaPath]
 
 
 class GelSchemaMetadata:
     class __gel_reflection__:  # noqa: N801
         id: ClassVar[uuid.UUID]
-        name: ClassVar[_reflection.SchemaPath]
+        name: ClassVar[SchemaPath]
 
 
 class GelSourceMetadata(GelSchemaMetadata):

--- a/gel/_internal/_qbmodel/_abstract/_expressions.py
+++ b/gel/_internal/_qbmodel/_abstract/_expressions.py
@@ -43,7 +43,7 @@ def _get_prefixed_ptr(
 
     ptr = getattr(cls, ptrname, Unspecified)
     if ptr is Unspecified:
-        sn = this_type.as_schema_name()
+        sn = str(this_type)
         msg = f"{ptrname} is not a valid {sn} property"
         raise AttributeError(msg)
     if not isinstance(ptr, _qb.PathAlias):

--- a/gel/_internal/_qbmodel/_abstract/_primitive.py
+++ b/gel/_internal/_qbmodel/_abstract/_primitive.py
@@ -201,7 +201,7 @@ class Array(  # type: ignore [misc]
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_array_type_id_and_name(
-            cls.__element_type__.__gel_reflection__.name.as_schema_name()
+            str(cls.__element_type__.__gel_reflection__.name)
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
@@ -282,8 +282,7 @@ class Tuple(  # type: ignore[misc]
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_tuple_type_id_and_name(
-            el.__gel_reflection__.name.as_schema_name()
-            for el in cls.__element_types__
+            str(el.__gel_reflection__.name) for el in cls.__element_types__
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
@@ -319,7 +318,7 @@ class Range(
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_range_type_id_and_name(
-            cls.__element_type__.__gel_reflection__.name.as_schema_name()
+            str(cls.__element_type__.__gel_reflection__.name)
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
@@ -612,7 +611,7 @@ _ambiguous_py_types: dict[
             for parent in {p.parent for p in scalars}
         }
         for key, scalars in {
-            key: tuple(SchemaPath.from_schema_name(v) for v in vals)
+            key: tuple(SchemaPath(v) for v in vals)
             for key, vals in _py_type_to_scalar_type.items()
         }.items()
         if len(scalars) > 1

--- a/gel/_internal/_qbmodel/_abstract/_primitive.py
+++ b/gel/_internal/_qbmodel/_abstract/_primitive.py
@@ -41,7 +41,7 @@ from gel._internal import _qb
 from gel._internal import _typing_parametric
 from gel._internal._lazyprop import LazyClassProperty
 from gel._internal._polyfills._strenum import StrEnum
-from gel._internal._reflection import SchemaPath
+from gel._internal._schemapath import SchemaPath
 
 from ._base import GelType, GelTypeConstraint, GelTypeMeta
 from ._functions import assert_single

--- a/gel/_internal/_reflection/__init__.py
+++ b/gel/_internal/_reflection/__init__.py
@@ -12,11 +12,6 @@ from ._enums import (
     TypeModifier,
 )
 
-from ._base import (
-    SchemaPath,
-    parse_name,
-)
-
 from ._casts import (
     CastMatrix,
     fetch_casts,
@@ -111,7 +106,6 @@ __all__ = (
     "PseudoType",
     "ScalarType",
     "SchemaPart",
-    "SchemaPath",
     "ServerVersion",
     "TupleType",
     "Type",
@@ -137,5 +131,4 @@ __all__ = (
     "is_range_type",
     "is_scalar_type",
     "is_tuple_type",
-    "parse_name",
 )

--- a/gel/_internal/_reflection/_base.py
+++ b/gel/_internal/_reflection/_base.py
@@ -4,97 +4,14 @@
 
 
 from __future__ import annotations
-from typing import Any, NamedTuple, TypeVar
+from typing import TypeVar
 from typing_extensions import dataclass_transform
 
 import dataclasses
 import functools
-import pathlib
-import sys
 import uuid
 
-from gel._internal import _edgeql
-
-
-class QualName(NamedTuple):
-    module: str
-    name: str
-
-
-if sys.version_info >= (3, 12):
-
-    class _SchemaPathParser:
-        sep = "::"
-        altsep: str | None = None
-
-        if sys.version_info >= (3, 13):
-
-            def __init__(self) -> None:
-                self._impl = pathlib.PurePosixPath.parser  # type: ignore [attr-defined]
-        else:
-
-            def __init__(self) -> None:
-                self._impl = pathlib.PurePosixPath._flavour  # type: ignore [attr-defined]
-
-        def splitroot(self, part: str, sep: str = sep) -> tuple[str, str, str]:
-            return "", "", part
-
-        def join(self, *parts: str) -> str:
-            return self.sep.join(parts)
-
-        def __getattr__(self, name: str) -> Any:
-            return getattr(self._impl, name)
-
-    class _SchemaPath(pathlib.PurePosixPath):
-        parser = _SchemaPathParser()
-        _flavour = parser
-else:
-
-    class _SchemaPathParser(pathlib._PosixFlavour):  # type: ignore [name-defined, misc]
-        sep = "::"
-        altsep: str | None = None
-
-        def splitroot(self, part: str, sep: str = sep) -> tuple[str, str, str]:
-            return "", "", part
-
-        def join(self, parts: list[str]) -> str:
-            return self.sep.join(parts)
-
-    class _SchemaPath(pathlib.PurePosixPath):
-        _flavour = _SchemaPathParser()
-
-
-class SchemaPath(_SchemaPath):
-    @classmethod
-    def from_schema_name(cls, name: str) -> SchemaPath:
-        parts = name.split("::")
-        return SchemaPath(*parts)
-
-    def common_parts(self, other: SchemaPath) -> list[str]:
-        prefix = []
-        for a, b in zip(self.parts, other.parts, strict=False):
-            if a == b:
-                prefix.append(a)
-            else:
-                break
-
-        return prefix
-
-    def has_prefix(self, other: SchemaPath) -> bool:
-        return self.parts[: len(other.parts)] == other.parts
-
-    def as_schema_name(self) -> str:
-        return "::".join(self.parts)
-
-    def as_quoted_schema_name(self) -> str:
-        return "::".join(_edgeql.quote_ident(p) for p in self.parts)
-
-    def as_code(self, clsname: str = "SchemaPath") -> str:
-        return f"{clsname}({', '.join(repr(p) for p in self.parts)})"
-
-
-def parse_name(name: str) -> SchemaPath:
-    return SchemaPath.from_schema_name(name)
+from gel._internal._schemapath import SchemaPath
 
 
 _T = TypeVar("_T")
@@ -128,7 +45,7 @@ class SchemaObject:
 
     @functools.cached_property
     def schemapath(self) -> SchemaPath:
-        return parse_name(self.name)
+        return SchemaPath.from_schema_name(self.name)
 
     @functools.cached_property
     def uuid(self) -> uuid.UUID:

--- a/gel/_internal/_reflection/_base.py
+++ b/gel/_internal/_reflection/_base.py
@@ -45,7 +45,7 @@ class SchemaObject:
 
     @functools.cached_property
     def schemapath(self) -> SchemaPath:
-        return SchemaPath.from_schema_name(self.name)
+        return SchemaPath(self.name)
 
     @functools.cached_property
     def uuid(self) -> uuid.UUID:

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -254,7 +254,7 @@ class CollectionType(Type):
 
     @functools.cached_property
     def schemapath(self) -> SchemaPath:
-        return SchemaPath(self.name)
+        return SchemaPath.from_segments(self.name)
 
 
 @struct

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -23,9 +23,10 @@ from collections import defaultdict
 
 from gel._internal import _dataclass_extras
 from gel._internal import _edgeql
+from gel._internal._schemapath import SchemaPath
 
 from . import _query
-from ._base import struct, sobject, SchemaObject, SchemaPath
+from ._base import struct, sobject, SchemaObject
 from ._enums import Cardinality, PointerKind, SchemaPart, TypeKind
 
 if TYPE_CHECKING:

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -399,7 +399,7 @@ def get_linked_new_objects(obj: GelModel) -> Iterable[GelModel]:
 
 
 def obj_to_name_ql(obj: GelModel) -> str:
-    return quote_ident(type(obj).__gel_reflection__.name.as_schema_name())
+    return type(obj).__gel_reflection__.name.as_quoted_schema_name()
 
 
 def shift_dict_list(inp: dict[str, list[T]]) -> dict[str, T]:

--- a/gel/_internal/_schemapath.py
+++ b/gel/_internal/_schemapath.py
@@ -5,64 +5,122 @@
 """Pathlib-like implementation for qualified schema names"""
 
 from __future__ import annotations
-from typing import Any
+from typing import SupportsIndex, TypeVar, overload
+from typing_extensions import Self, TypeAliasType
+from collections.abc import Sequence
 
+import functools
 import pathlib
-import sys
 
 from gel._internal import _edgeql
 
 
-if sys.version_info >= (3, 12):
-
-    class _SchemaPathParser:
-        sep = "::"
-        altsep: str | None = None
-
-        if sys.version_info >= (3, 13):
-
-            def __init__(self) -> None:
-                self._impl = pathlib.PurePosixPath.parser  # type: ignore [attr-defined]
-        else:
-
-            def __init__(self) -> None:
-                self._impl = pathlib.PurePosixPath._flavour  # type: ignore [attr-defined]
-
-        def splitroot(self, part: str, sep: str = sep) -> tuple[str, str, str]:
-            return "", "", part
-
-        def join(self, *parts: str) -> str:
-            return self.sep.join(parts)
-
-        def __getattr__(self, name: str) -> Any:
-            return getattr(self._impl, name)
-
-    class _SchemaPath(pathlib.PurePosixPath):
-        parser = _SchemaPathParser()
-        _flavour = parser
-else:
-
-    class _SchemaPathParser(pathlib._PosixFlavour):  # type: ignore [name-defined, misc]
-        sep = "::"
-        altsep: str | None = None
-
-        def splitroot(self, part: str, sep: str = sep) -> tuple[str, str, str]:
-            return "", "", part
-
-        def join(self, parts: list[str]) -> str:
-            return self.sep.join(parts)
-
-    class _SchemaPath(pathlib.PurePosixPath):
-        _flavour = _SchemaPathParser()
+_SEP = "::"
 
 
-class SchemaPath(_SchemaPath):
+SchemaPathLike = TypeAliasType("SchemaPathLike", "str | SchemaPath")
+
+
+class SchemaPath:
     @classmethod
-    def from_schema_name(cls, name: str) -> SchemaPath:
-        parts = name.split("::")
-        return SchemaPath(*parts)
+    def from_segments(cls, *names: str) -> Self:
+        """Construct a SchemaPath from individual segments.  Unlike
+        the main constructor, no attempt is made to further split
+        each segment.  This is useful for names that contain `::`
+        in their unqualified part, such as collection types."""
+        return cls._from_parsed_parts(names)
+
+    def __init__(self, *args: SchemaPathLike) -> None:
+        paths = []
+        for arg in args:
+            if isinstance(arg, SchemaPath):
+                paths.extend(arg._raw_paths)
+            elif isinstance(arg, str):
+                paths.append(arg)
+            else:
+                raise TypeError(
+                    "argument should be a str or a SchemaPath "
+                    f"not {type(arg).__name__!r}"
+                )
+
+        self._raw_paths: list[str] = paths
+
+    def __truediv__(self, other: SchemaPathLike) -> Self:
+        try:
+            return type(self)(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __rtruediv__(self, other: SchemaPathLike) -> Self:
+        try:
+            return type(self)(other, self)
+        except TypeError:
+            return NotImplemented
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SchemaPath):
+            return NotImplemented
+        return self._str == other._str
+
+    def __hash__(self) -> int:
+        return self._hash
+
+    def __lt__(self, other: SchemaPath) -> bool:
+        if not isinstance(other, SchemaPath):
+            return NotImplemented
+        return self.parts < other.parts
+
+    def __le__(self, other: SchemaPath) -> bool:
+        if not isinstance(other, SchemaPath):
+            return NotImplemented
+        return self.parts <= other.parts
+
+    def __gt__(self, other: SchemaPath) -> bool:
+        if not isinstance(other, SchemaPath):
+            return NotImplemented
+        return self.parts > other.parts
+
+    def __ge__(self, other: SchemaPath) -> bool:
+        if not isinstance(other, SchemaPath):
+            return NotImplemented
+        return self.parts >= other.parts
+
+    def __str__(self) -> str:
+        return self._str
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({str(self)!r})"
+
+    @functools.cached_property
+    def parts(self) -> tuple[str, ...]:
+        """A sequence of components of the schema path."""
+        parts: list[str] = []
+        for raw_path in self._raw_paths:
+            # Strip leading and trailing separators before splitting
+            path = raw_path.strip(_SEP)
+            parts.extend(filter(None, path.split(_SEP)))
+        return tuple(parts)
+
+    @property
+    def name(self) -> str:
+        """The final path component."""
+        return self.parts[-1]
+
+    @property
+    def parent(self) -> Self:
+        """The logical parent of the path."""
+        return self._from_parsed_parts(self.parts[:-1])
+
+    @property
+    def parents(self) -> Sequence[Self]:
+        """A sequence of this path's logical parents."""
+        # The value of this property should not be cached on the path object,
+        # as doing so would introduce a reference cycle.
+        return _SchemaPathParents(self)
 
     def common_parts(self, other: SchemaPath) -> list[str]:
+        """Return a list of segments that form common prefix between this
+        and the other path."""
         prefix = []
         for a, b in zip(self.parts, other.parts, strict=False):
             if a == b:
@@ -72,14 +130,79 @@ class SchemaPath(_SchemaPath):
 
         return prefix
 
+    def is_relative_to(self, other: SchemaPathLike) -> bool:
+        """Determine if the path is relative to another path."""
+        if not isinstance(other, SchemaPath):
+            other = type(self)(other)
+        return other == self or other in self.parents
+
     def has_prefix(self, other: SchemaPath) -> bool:
         return self.parts[: len(other.parts)] == other.parts
 
-    def as_schema_name(self) -> str:
-        return "::".join(self.parts)
-
     def as_quoted_schema_name(self) -> str:
-        return "::".join(_edgeql.quote_ident(p) for p in self.parts)
+        return _SEP.join(_edgeql.quote_ident(p) for p in self.parts)
 
     def as_code(self, clsname: str = "SchemaPath") -> str:
-        return f"{clsname}({', '.join(repr(p) for p in self.parts)})"
+        parts = ", ".join(repr(p) for p in self.parts)
+        return f"{clsname}.from_segments({parts})"
+
+    def as_pathlib_path(self) -> pathlib.Path:
+        return pathlib.Path(*self.parts)
+
+    @functools.cached_property
+    def _str(self) -> str:
+        return _SEP.join(self.parts)
+
+    @functools.cached_property
+    def _hash(self) -> int:
+        return hash(self._str)
+
+    @classmethod
+    def _from_parsed_parts(cls, parts: tuple[str, ...]) -> Self:
+        path = cls(*parts)
+        path.__dict__["parts"] = parts
+        path.__dict__["_str"] = _SEP.join(parts)
+        path.__dict__["_hash"] = hash(path._str)
+        return path
+
+
+_T = TypeVar("_T", bound=SchemaPath)
+
+
+class _SchemaPathParents(Sequence[_T]):
+    """This object provides sequence-like access to the logical ancestors
+    of a path."""
+
+    __slots__ = ("_parts", "_path")
+
+    def __init__(self, path: _T) -> None:
+        self._path = path
+        self._parts = path.parts
+
+    def __len__(self) -> int:
+        return len(self._parts)
+
+    @overload
+    def __getitem__(self, idx: SupportsIndex) -> _T: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> Sequence[_T]: ...
+
+    def __getitem__(self, idx: SupportsIndex | slice) -> _T | Sequence[_T]:
+        self_len = len(self)
+
+        if isinstance(idx, slice):
+            return tuple(self[i] for i in range(*idx.indices(self_len)))
+        else:
+            idx = idx.__index__()
+
+        if idx >= self_len or idx < -self_len:
+            raise IndexError(idx)
+
+        if idx < 0:
+            idx += self_len
+
+        return self._path._from_parsed_parts(self._parts[: -idx - 1])
+
+    def __repr__(self) -> str:
+        return f"<{type(self._path).__name__}.parents>"

--- a/gel/_internal/_schemapath.py
+++ b/gel/_internal/_schemapath.py
@@ -1,0 +1,85 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+"""Pathlib-like implementation for qualified schema names"""
+
+from __future__ import annotations
+from typing import Any
+
+import pathlib
+import sys
+
+from gel._internal import _edgeql
+
+
+if sys.version_info >= (3, 12):
+
+    class _SchemaPathParser:
+        sep = "::"
+        altsep: str | None = None
+
+        if sys.version_info >= (3, 13):
+
+            def __init__(self) -> None:
+                self._impl = pathlib.PurePosixPath.parser  # type: ignore [attr-defined]
+        else:
+
+            def __init__(self) -> None:
+                self._impl = pathlib.PurePosixPath._flavour  # type: ignore [attr-defined]
+
+        def splitroot(self, part: str, sep: str = sep) -> tuple[str, str, str]:
+            return "", "", part
+
+        def join(self, *parts: str) -> str:
+            return self.sep.join(parts)
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._impl, name)
+
+    class _SchemaPath(pathlib.PurePosixPath):
+        parser = _SchemaPathParser()
+        _flavour = parser
+else:
+
+    class _SchemaPathParser(pathlib._PosixFlavour):  # type: ignore [name-defined, misc]
+        sep = "::"
+        altsep: str | None = None
+
+        def splitroot(self, part: str, sep: str = sep) -> tuple[str, str, str]:
+            return "", "", part
+
+        def join(self, parts: list[str]) -> str:
+            return self.sep.join(parts)
+
+    class _SchemaPath(pathlib.PurePosixPath):
+        _flavour = _SchemaPathParser()
+
+
+class SchemaPath(_SchemaPath):
+    @classmethod
+    def from_schema_name(cls, name: str) -> SchemaPath:
+        parts = name.split("::")
+        return SchemaPath(*parts)
+
+    def common_parts(self, other: SchemaPath) -> list[str]:
+        prefix = []
+        for a, b in zip(self.parts, other.parts, strict=False):
+            if a == b:
+                prefix.append(a)
+            else:
+                break
+
+        return prefix
+
+    def has_prefix(self, other: SchemaPath) -> bool:
+        return self.parts[: len(other.parts)] == other.parts
+
+    def as_schema_name(self) -> str:
+        return "::".join(self.parts)
+
+    def as_quoted_schema_name(self) -> str:
+        return "::".join(_edgeql.quote_ident(p) for p in self.parts)
+
+    def as_code(self, clsname: str = "SchemaPath") -> str:
+        return f"{clsname}({', '.join(repr(p) for p in self.parts)})"

--- a/gel/models/pydantic.py
+++ b/gel/models/pydantic.py
@@ -13,7 +13,7 @@ from pydantic import (
 from gel._internal._deferred_import import DeferredImport
 from gel._internal._edgeql import Cardinality, PointerKind
 from gel._internal._lazyprop import LazyClassProperty
-from gel._internal._reflection import SchemaPath
+from gel._internal._schemapath import SchemaPath
 from gel._internal._typing_dispatch import dispatch_overload
 from gel._internal._utils import UnspecifiedType, Unspecified
 from gel._internal._xmethod import classonlymethod

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -3428,7 +3428,7 @@ class TestModelGenerator(tb.ModelTestCase):
 
         ntup_t = default.sub.TypeInSub.__gel_reflection__.pointers["ntup"].type
         self.assertEqual(
-            ntup_t.as_schema_name(),
+            str(ntup_t),
             "tuple<a:std::str, b:tuple<c:std::int64, d:std::str>>",
         )
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -43,7 +43,7 @@ from gel._internal._qbmodel._pydantic._models import GelModel
 from gel._internal._qbmodel._pydantic._pdlist import (
     ProxyDistinctList,
 )
-from gel._internal._reflection import SchemaPath
+from gel._internal._schemapath import SchemaPath
 
 
 @dataclasses.dataclass

--- a/tests/test_schemapath.py
+++ b/tests/test_schemapath.py
@@ -1,0 +1,587 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import pathlib
+from typing import Any
+
+from gel._internal._schemapath import SchemaPath
+
+
+class TestSchemaPath(unittest.TestCase):
+    """Test suite for SchemaPath class."""
+
+    def test_schemapath_basic_construction(self):
+        """Test basic construction from string."""
+        path = SchemaPath("std::int64")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+        self.assertEqual(path.name, "int64")
+
+    def test_schemapath_single_segment(self):
+        """Test construction with single segment."""
+        path = SchemaPath("MyType")
+        self.assertEqual(str(path), "MyType")
+        self.assertEqual(path.parts, ("MyType",))
+        self.assertEqual(path.name, "MyType")
+
+    def test_schemapath_multiple_segments(self):
+        """Test construction with multiple segments."""
+        path = SchemaPath("std::cal::local_time")
+        self.assertEqual(str(path), "std::cal::local_time")
+        self.assertEqual(path.parts, ("std", "cal", "local_time"))
+        self.assertEqual(path.name, "local_time")
+
+    def test_schemapath_empty_string(self):
+        """Test construction with empty string."""
+        path = SchemaPath("")
+        self.assertEqual(str(path), "")
+        self.assertEqual(path.parts, ())
+
+    def test_schemapath_from_segments(self):
+        """Test from_segments class method."""
+        path = SchemaPath.from_segments("std", "int64")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+        self.assertEqual(path.name, "int64")
+
+    def test_schemapath_from_segments_with_separator(self):
+        """Test from_segments with segments containing separator."""
+        # This is the key use case: collection types with :: in their name
+        path = SchemaPath.from_segments("array<std::int64>")
+        self.assertEqual(str(path), "array<std::int64>")
+        self.assertEqual(path.parts, ("array<std::int64>",))
+        self.assertEqual(path.name, "array<std::int64>")
+
+    def test_schemapath_from_segments_multiple_with_separator(self):
+        """Test from_segments with multiple segments containing separator."""
+        path = SchemaPath.from_segments("std", "array<std::int64>")
+        self.assertEqual(str(path), "std::array<std::int64>")
+        self.assertEqual(path.parts, ("std", "array<std::int64>"))
+        self.assertEqual(path.name, "array<std::int64>")
+
+    def test_schemapath_multiple_arguments(self):
+        """Test construction with multiple string arguments."""
+        path = SchemaPath("std", "cal", "local_time")
+        self.assertEqual(str(path), "std::cal::local_time")
+        self.assertEqual(path.parts, ("std", "cal", "local_time"))
+
+    def test_schemapath_mixed_arguments(self):
+        """Test construction with mixed string and SchemaPath arguments."""
+        path1 = SchemaPath("std::cal")
+        path2 = SchemaPath(path1, "local_time")
+        self.assertEqual(str(path2), "std::cal::local_time")
+        self.assertEqual(path2.parts, ("std", "cal", "local_time"))
+
+    def test_schemapath_schemapath_argument(self):
+        """Test construction from another SchemaPath."""
+        path1 = SchemaPath("std::int64")
+        path2 = SchemaPath(path1)
+        self.assertEqual(str(path2), "std::int64")
+        self.assertEqual(path2.parts, ("std", "int64"))
+        self.assertIsNot(path1, path2)
+
+    def test_schemapath_invalid_argument_type(self):
+        """Test construction with invalid argument type."""
+        with self.assertRaises(TypeError):
+            SchemaPath(123)  # type: ignore
+
+    def test_schemapath_truediv_operator(self):
+        """Test / operator with SchemaPath."""
+        path1 = SchemaPath("std")
+        path2 = SchemaPath("int64")
+        result = path1 / path2
+        self.assertEqual(str(result), "std::int64")
+        self.assertEqual(result.parts, ("std", "int64"))
+
+    def test_schemapath_truediv_operator_string(self):
+        """Test / operator with string."""
+        path = SchemaPath("std")
+        result = path / "int64"
+        self.assertEqual(str(result), "std::int64")
+        self.assertEqual(result.parts, ("std", "int64"))
+
+    def test_schemapath_rtruediv_operator(self):
+        """Test reverse / operator."""
+        path = SchemaPath("int64")
+        result = "std" / path
+        self.assertEqual(str(result), "std::int64")
+        self.assertEqual(result.parts, ("std", "int64"))
+
+    def test_schemapath_truediv_invalid_type(self):
+        """Test / operator with invalid type."""
+        path = SchemaPath("std")
+        with self.assertRaises(TypeError):
+            path / 123  # type: ignore
+
+    def test_schemapath_equality(self):
+        """Test equality comparison."""
+        path1 = SchemaPath("std::int64")
+        path2 = SchemaPath("std::int64")
+        path3 = SchemaPath("std::str")
+
+        self.assertEqual(path1, path2)
+        self.assertNotEqual(path1, path3)
+        self.assertNotEqual(path1, "std::int64")  # Different type
+
+    def test_schemapath_hash(self):
+        """Test hash function."""
+        path1 = SchemaPath("std::int64")
+        path2 = SchemaPath("std::int64")
+        path3 = SchemaPath("std::str")
+
+        self.assertEqual(hash(path1), hash(path2))
+        self.assertNotEqual(hash(path1), hash(path3))
+
+        # Test that paths can be used as dictionary keys
+        d = {path1: "value1", path3: "value3"}
+        self.assertEqual(d[path2], "value1")
+
+    def test_schemapath_ordering(self):
+        """Test ordering operations."""
+        path1 = SchemaPath("a::b")
+        path2 = SchemaPath("a::c")
+        path3 = SchemaPath("b::a")
+
+        self.assertLess(path1, path2)
+        self.assertLessEqual(path1, path2)
+        self.assertLessEqual(path1, path1)
+        self.assertGreater(path3, path1)
+        self.assertGreaterEqual(path3, path1)
+        self.assertGreaterEqual(path1, path1)
+
+    def test_schemapath_ordering_invalid_type(self):
+        """Test ordering with invalid types."""
+        path = SchemaPath("std::int64")
+
+        self.assertEqual(path.__lt__("invalid"), NotImplemented)
+        self.assertEqual(path.__le__("invalid"), NotImplemented)
+        self.assertEqual(path.__gt__("invalid"), NotImplemented)
+        self.assertEqual(path.__ge__("invalid"), NotImplemented)
+
+    def test_schemapath_str_and_repr(self):
+        """Test string representation."""
+        path = SchemaPath("std::int64")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(repr(path), "SchemaPath('std::int64')")
+
+    def test_schemapath_parent(self):
+        """Test parent property."""
+        path = SchemaPath("std::cal::local_time")
+        parent = path.parent
+        self.assertEqual(str(parent), "std::cal")
+        self.assertEqual(parent.parts, ("std", "cal"))
+
+    def test_schemapath_parent_single_segment(self):
+        """Test parent of single segment path."""
+        path = SchemaPath("MyType")
+        parent = path.parent
+        self.assertEqual(str(parent), "")
+        self.assertEqual(parent.parts, ())
+
+    def test_schemapath_parent_empty(self):
+        """Test parent of empty path."""
+        path = SchemaPath("MyType")
+        parent = path.parent
+        self.assertEqual(str(parent), "")
+        self.assertEqual(parent.parts, ())
+
+    def test_schemapath_parents(self):
+        """Test parents property."""
+        path = SchemaPath("std::cal::local_time")
+        parents = path.parents
+
+        self.assertEqual(len(parents), 3)
+        self.assertEqual(str(parents[0]), "std::cal")
+        self.assertEqual(str(parents[1]), "std")
+        self.assertEqual(str(parents[2]), "")
+
+    def test_schemapath_parents_indexing(self):
+        """Test parents indexing including negative indices."""
+        path = SchemaPath("a::b::c::d")
+        parents = path.parents
+
+        self.assertEqual(len(parents), 4)
+        self.assertEqual(str(parents[0]), "a::b::c")
+        self.assertEqual(str(parents[1]), "a::b")
+        self.assertEqual(str(parents[2]), "a")
+        self.assertEqual(str(parents[3]), "")
+
+        # Test negative indexing
+        self.assertEqual(str(parents[-1]), "")
+        self.assertEqual(str(parents[-2]), "a")
+        self.assertEqual(str(parents[-3]), "a::b")
+        self.assertEqual(str(parents[-4]), "a::b::c")
+
+    def test_schemapath_parents_slicing(self):
+        """Test parents slicing."""
+        path = SchemaPath("a::b::c::d")
+        parents = path.parents
+
+        slice_result = parents[1:3]
+        self.assertEqual(len(slice_result), 2)
+        self.assertEqual(str(slice_result[0]), "a::b")
+        self.assertEqual(str(slice_result[1]), "a")
+
+    def test_schemapath_parents_index_error(self):
+        """Test parents index out of bounds."""
+        path = SchemaPath("a::b")
+        parents = path.parents
+
+        with self.assertRaises(IndexError):
+            parents[5]
+
+        with self.assertRaises(IndexError):
+            parents[-5]
+
+    def test_schemapath_parents_repr(self):
+        """Test parents repr."""
+        path = SchemaPath("std::int64")
+        parents = path.parents
+        self.assertEqual(repr(parents), "<SchemaPath.parents>")
+
+    def test_schemapath_common_parts(self):
+        """Test common_parts method."""
+        path1 = SchemaPath("std::cal::local_time")
+        path2 = SchemaPath("std::cal::local_date")
+        path3 = SchemaPath("std::str")
+        path4 = SchemaPath("user::MyType")
+
+        self.assertEqual(path1.common_parts(path2), ["std", "cal"])
+        self.assertEqual(path1.common_parts(path3), ["std"])
+        self.assertEqual(path1.common_parts(path4), [])
+
+    def test_schemapath_is_relative_to(self):
+        """Test is_relative_to method."""
+        path = SchemaPath("std::cal::local_time")
+
+        self.assertTrue(path.is_relative_to("std"))
+        self.assertTrue(path.is_relative_to("std::cal"))
+        self.assertTrue(path.is_relative_to("std::cal::local_time"))
+        self.assertFalse(path.is_relative_to("std::cal::local_date"))
+        self.assertFalse(path.is_relative_to("user"))
+
+    def test_schemapath_is_relative_to_schemapath(self):
+        """Test is_relative_to with SchemaPath argument."""
+        path = SchemaPath("std::cal::local_time")
+        base = SchemaPath("std::cal")
+
+        self.assertTrue(path.is_relative_to(base))
+
+    def test_schemapath_has_prefix(self):
+        """Test has_prefix method."""
+        path = SchemaPath("std::cal::local_time")
+
+        self.assertTrue(path.has_prefix(SchemaPath("std")))
+        self.assertTrue(path.has_prefix(SchemaPath("std::cal")))
+        self.assertTrue(path.has_prefix(SchemaPath("std::cal::local_time")))
+        self.assertFalse(path.has_prefix(SchemaPath("std::cal::local_date")))
+        self.assertFalse(path.has_prefix(SchemaPath("user")))
+
+    def test_schemapath_as_quoted_schema_name(self):
+        """Test as_quoted_schema_name method."""
+        path = SchemaPath("std::int64")
+        # This test assumes quote_ident just quotes identifiers normally
+        # The actual behavior depends on the _edgeql.quote_ident function
+        quoted = path.as_quoted_schema_name()
+        self.assertIn("::", quoted)
+        self.assertTrue(quoted.startswith("std") or quoted.startswith("`std`"))
+
+    def test_schemapath_as_code(self):
+        """Test as_code method."""
+        path = SchemaPath("std::int64")
+        code = path.as_code()
+        self.assertEqual(code, "SchemaPath.from_segments('std', 'int64')")
+
+    def test_schemapath_as_code_custom_classname(self):
+        """Test as_code method with custom class name."""
+        path = SchemaPath("std::int64")
+        code = path.as_code("MySchemaPath")
+        self.assertEqual(code, "MySchemaPath.from_segments('std', 'int64')")
+
+    def test_schemapath_as_pathlib_path(self):
+        """Test as_pathlib_path method."""
+        path = SchemaPath("std::cal::local_time")
+        pathlib_path = path.as_pathlib_path()
+        self.assertIsInstance(pathlib_path, pathlib.Path)
+        self.assertEqual(str(pathlib_path), "std/cal/local_time")
+
+    def test_schemapath_caching(self):
+        """Test that properties are properly cached."""
+        path = SchemaPath("std::cal::local_time")
+
+        # Access parts multiple times to ensure caching works
+        parts1 = path.parts
+        parts2 = path.parts
+        self.assertIs(parts1, parts2)
+
+        # Access string representation multiple times
+        str1 = path._str
+        str2 = path._str
+        self.assertIs(str1, str2)
+
+    def test_schemapath_edge_cases_leading_separator(self):
+        """Test that leading separators are normalized (stripped)."""
+        path = SchemaPath("::std::int64")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+
+    def test_schemapath_edge_cases_trailing_separator(self):
+        """Test that trailing separators are normalized (stripped)."""
+        path = SchemaPath("std::int64::")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+
+    def test_schemapath_edge_cases_consecutive_separators(self):
+        """Test that consecutive separators are collapsed."""
+        path = SchemaPath("std::::int64")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+
+    def test_schemapath_normalization_both_separators(self):
+        """Test normalization of both leading and trailing separators."""
+        path = SchemaPath("::std::int64::")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+
+        # Test that normalized paths are equal to non-normalized ones
+        normal_path = SchemaPath("std::int64")
+        self.assertEqual(path, normal_path)
+        self.assertEqual(hash(path), hash(normal_path))
+
+    def test_schemapath_normalization_multiple_separators(self):
+        """Test normalization with multiple leading/trailing separators."""
+        path = SchemaPath("::::std::int64::::")
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+
+    def test_schemapath_normalization_empty_path(self):
+        """Test normalization of path with only separators."""
+        path = SchemaPath("::")
+        self.assertEqual(str(path), "")
+        self.assertEqual(path.parts, ())
+
+    def test_schemapath_consecutive_separator_collapsing(self):
+        """Test that consecutive separators are collapsed to
+        single separators."""
+        # Test various forms of consecutive separators
+        test_cases = [
+            ("std::::int64", "std::int64"),
+            ("::std::::int64::", "std::int64"),
+            ("std::::::cal::::local_time", "std::cal::local_time"),
+            ("a::::b::::c", "a::b::c"),
+            (":::::::", ""),
+        ]
+
+        for input_path, expected in test_cases:
+            with self.subTest(input_path=input_path):
+                path = SchemaPath(input_path)
+                self.assertEqual(str(path), expected)
+
+    def test_schemapath_mixed_normalization(self):
+        """Test complex cases with mixed leading/trailing/consecutive
+        separators."""
+        path = SchemaPath("::std::::cal::::local_time::")
+        self.assertEqual(str(path), "std::cal::local_time")
+        self.assertEqual(path.parts, ("std", "cal", "local_time"))
+
+        # Test equality with normalized path
+        normal_path = SchemaPath("std::cal::local_time")
+        self.assertEqual(path, normal_path)
+        self.assertEqual(hash(path), hash(normal_path))
+
+    def test_schemapath_complex_collection_type(self):
+        """Test complex collection type using from_segments."""
+        # Test a complex nested collection type
+        path = SchemaPath.from_segments(
+            "std", "array<tuple<std::str, std::int64>>"
+        )
+        self.assertEqual(str(path), "std::array<tuple<std::str, std::int64>>")
+        self.assertEqual(
+            path.parts, ("std", "array<tuple<std::str, std::int64>>")
+        )
+        self.assertEqual(path.name, "array<tuple<std::str, std::int64>>")
+
+    def test_schemapath_comparison_with_different_lengths(self):
+        """Test comparison between paths of different lengths."""
+        path1 = SchemaPath("std")
+        path2 = SchemaPath("std::int64")
+
+        self.assertLess(path1, path2)
+        self.assertGreater(path2, path1)
+
+    def test_schemapath_type_alias_compatibility(self):
+        """Test that SchemaPath works with SchemaPathLike type alias."""
+
+        def process_path(path: Any) -> str:
+            if isinstance(path, str):
+                return SchemaPath(path).name
+            elif isinstance(path, SchemaPath):
+                return path.name
+            else:
+                raise TypeError("Expected SchemaPathLike")
+
+        # Test with string
+        self.assertEqual(process_path("std::int64"), "int64")
+
+        # Test with SchemaPath
+        path = SchemaPath("std::int64")
+        self.assertEqual(process_path(path), "int64")
+
+    def test_schemapath_immutability(self):
+        """Test that SchemaPath behaves as immutable."""
+        path = SchemaPath("std::int64")
+
+        # Accessing parts shouldn't modify the object
+        parts = path.parts
+        self.assertEqual(parts, ("std", "int64"))
+
+        # Creating new paths from operations shouldn't modify original
+        new_path = path / "extended"
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(str(new_path), "std::int64::extended")
+
+    def test_schemapath_from_parsed_parts_optimization(self):
+        """Test that _from_parsed_parts properly optimizes construction."""
+        # This tests the internal optimization where parts are pre-computed
+        path = SchemaPath._from_parsed_parts(("std", "int64"))
+        self.assertEqual(str(path), "std::int64")
+        self.assertEqual(path.parts, ("std", "int64"))
+        self.assertEqual(path.name, "int64")
+
+    def test_schemapath_sorting(self):
+        """Test that SchemaPath objects can be sorted."""
+        paths = [
+            SchemaPath("std::str"),
+            SchemaPath("std::int64"),
+            SchemaPath("std::cal::local_time"),
+            SchemaPath("user::MyType"),
+        ]
+
+        sorted_paths = sorted(paths)
+        expected_order = [
+            "std::cal::local_time",
+            "std::int64",
+            "std::str",
+            "user::MyType",
+        ]
+
+        self.assertEqual([str(p) for p in sorted_paths], expected_order)
+
+    def test_schemapath_validation_empty_segments(self):
+        """Test that empty segments in from_segments are preserved."""
+        path = SchemaPath.from_segments("std", "", "int64")
+        self.assertEqual(path.parts, ("std", "", "int64"))
+        self.assertEqual(str(path), "std::::int64")
+
+    def test_schemapath_validation_only_separator(self):
+        """Test that path with only separators becomes empty."""
+        path = SchemaPath("::")
+        self.assertEqual(str(path), "")
+        self.assertEqual(path.parts, ())
+
+    def test_schemapath_permissive_behavior(self):
+        """Test that various edge cases are handled permissively."""
+        test_cases = [
+            (":::", "", ()),
+            ("std:::int64", "std:::int64", ("std", ":int64")),
+            ("::std", "std", ("std",)),
+            ("std::", "std", ("std",)),
+            ("std:::", "std", ("std",)),
+        ]
+
+        for input_path, expected_str, expected_parts in test_cases:
+            with self.subTest(input_path=input_path):
+                path = SchemaPath(input_path)
+                self.assertEqual(str(path), expected_str)
+                self.assertEqual(path.parts, expected_parts)
+
+    def test_schemapath_comprehensive_permissive_behavior(self):
+        """Test comprehensive documentation of all permissive behaviors."""
+
+        # Test 1: Empty paths are allowed
+        empty_cases = [
+            ("", "", ()),
+            ("::", "", ()),
+            ("::::", "", ()),
+            ("::::::", "", ()),
+        ]
+
+        for input_path, expected_str, expected_parts in empty_cases:
+            with self.subTest(category="empty", input_path=input_path):
+                path = SchemaPath(input_path)
+                self.assertEqual(str(path), expected_str)
+                self.assertEqual(path.parts, expected_parts)
+
+        # Test 2: Leading/trailing separators are normalized
+        normalization_cases = [
+            ("::std::int64", "std::int64", ("std", "int64")),
+            ("std::int64::", "std::int64", ("std", "int64")),
+            ("::std::int64::", "std::int64", ("std", "int64")),
+            ("::::std::int64::::", "std::int64", ("std", "int64")),
+        ]
+
+        for input_path, expected_str, expected_parts in normalization_cases:
+            with self.subTest(category="normalization", input_path=input_path):
+                path = SchemaPath(input_path)
+                self.assertEqual(str(path), expected_str)
+                self.assertEqual(path.parts, expected_parts)
+
+        # Test 3: Consecutive separators are collapsed
+        collapse_cases = [
+            ("std::::int64", "std::int64", ("std", "int64")),
+            (
+                "std::::::cal::::local_time",
+                "std::cal::local_time",
+                ("std", "cal", "local_time"),
+            ),
+            ("a::::b::::c::::d", "a::b::c::d", ("a", "b", "c", "d")),
+        ]
+
+        for input_path, expected_str, expected_parts in collapse_cases:
+            with self.subTest(category="collapse", input_path=input_path):
+                path = SchemaPath(input_path)
+                self.assertEqual(str(path), expected_str)
+                self.assertEqual(path.parts, expected_parts)
+
+        # Test 4: Complex mixed cases
+        mixed_cases = [
+            (
+                "::std::::cal::::local_time::",
+                "std::cal::local_time",
+                ("std", "cal", "local_time"),
+            ),
+            ("::::a::::b::::c::::", "a::b::c", ("a", "b", "c")),
+            ("::::::std::::::int64::::::", "std::int64", ("std", "int64")),
+        ]
+
+        for input_path, expected_str, expected_parts in mixed_cases:
+            with self.subTest(category="mixed", input_path=input_path):
+                path = SchemaPath(input_path)
+                self.assertEqual(str(path), expected_str)
+                self.assertEqual(path.parts, expected_parts)
+
+        # Test 5: Equality after normalization
+        path1 = SchemaPath("std::int64")
+        path2 = SchemaPath("::std::::int64::")
+        self.assertEqual(path1, path2)
+        self.assertEqual(hash(path1), hash(path2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Subclassing from `pathlib.PurePosixPath` is cute and all, but given all
the churn upstream across recent Python versions as well as possible
future fragility, stop trying to force pathlib to handle `::` as a path
separator and reimplement just enough of the API to support current
usage.
