### PR TITLE
Tidy up reflected types in user-defined part of schema at the top level

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -728,7 +728,15 @@ class BaseGeneratedModule:
         self._schema_part = schema_part
         self._is_package = self.mod_is_package(modname, schema_part)
         self._py_files = {
-            ModuleAspect.MAIN: GeneratedModule(COMMENT, BASE_IMPL),
+            ModuleAspect.MAIN: GeneratedModule(
+                COMMENT,
+                BASE_IMPL,
+                code_preamble=(
+                    '__gel_default_variant__ = "Default"'
+                    if self._schema_part is reflection.SchemaPart.USER
+                    else None
+                ),
+            ),
             ModuleAspect.VARIANTS: GeneratedModule(COMMENT, BASE_IMPL),
             ModuleAspect.LATE: GeneratedModule(COMMENT, BASE_IMPL),
         }
@@ -4202,9 +4210,7 @@ class GeneratedSchemaModule(BaseGeneratedModule):
         objtype: reflection.ObjectType,
     ) -> None:
         self.write()
-        self.write("#")
-        self.write(f"# type {objtype.name}")
-        self.write("#")
+        self.write()
 
         type_name = objtype.schemapath
         name = type_name.name
@@ -4224,8 +4230,14 @@ class GeneratedSchemaModule(BaseGeneratedModule):
         with self._class_def(
             name,
             base_types,
-            class_kwargs={"__gel_variant__": '"Default"'},
+            class_kwargs=(
+                {}
+                if self._schema_part is reflection.SchemaPart.USER
+                else {"__gel_variant__": '"Default"'}
+            ),
         ):
+            self.write(f'"""type {objtype.name}"""')
+            self.write()
             pointers = _get_object_type_body(objtype)
             if pointers:
                 localns = frozenset(ptr.name for ptr in pointers)

--- a/gel/_internal/_codegen/_module.py
+++ b/gel/_internal/_codegen/_module.py
@@ -252,7 +252,13 @@ def _in_ns(imported: str, ns: AbstractSet[str] | None) -> bool:
 class GeneratedModule:
     INDENT = " " * 4
 
-    def __init__(self, preamble: str, substrate_module: str) -> None:
+    def __init__(
+        self,
+        preamble: str,
+        substrate_module: str,
+        *,
+        code_preamble: str | None = None,
+    ) -> None:
         self._comment_preamble = preamble
         self._indent_level = 0
         self._in_type_checking = False
@@ -267,6 +273,7 @@ class GeneratedModule:
         self._typevars: defaultdict[str, dict[str | None, str]] = defaultdict(
             dict
         )
+        self._code_preamble = code_preamble
 
     def has_content(self) -> bool:
         return any(
@@ -820,6 +827,9 @@ class GeneratedModule:
         out.write("\n\n")
         out.write("from __future__ import annotations\n\n")
         out.write(self.render_imports())
+        if self._code_preamble:
+            out.write("\n\n\n")
+            out.write(self._code_preamble)
         if typevars:
             out.write("\n\n\n")
             out.write(typevars)


### PR DESCRIPTION
Now:
```
  #
  # type default::Image
  #
  class Image(base_variants.Image, __gel_variant__="Default"):
    file: std.str
    author: RequiredLinkWithProps[Image.__links__.author, User]
```
Will be:
```
  class Image(base_variants.Image):
    """type default::Image"""

    file: std.str
    author: RequiredLinkWithProps[Image.__links__.author, User]
```
Doc string comment is also important of we inherit some weird stuff like
```
   !!! abstract "Usage Documentation"
   [Models](../concepts/models.md)
```
which I'm not even sure what's the source of.