### PR TITLE
models: Ban `<expr> is [not] None`

### DIFF
--- a/gel/_internal/_is_overload.py
+++ b/gel/_internal/_is_overload.py
@@ -177,7 +177,7 @@ class _IsTransformer(ast.NodeTransformer):
         """
         return self._num_transforms
 
-    def visit_Compare(self, node: ast.Compare) -> ast.AST:  # noqa: N802
+    def visit_Compare(self, node: ast.Compare) -> ast.AST:
         """Visit a `Compare` node and transform `is` and `is not`
         operations.
         """

--- a/gel/_internal/_is_overload.py
+++ b/gel/_internal/_is_overload.py
@@ -1,0 +1,209 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+"""AST transformation to overload the `is` and `is not` operators.
+
+This module provides a decorator that transform a function's source to
+replace `is` and `is not` operations with calls to `__gel_is__` and
+`__gel_is_not__` methods on the left-hand operand. This allows objects
+to customize the behavior of identity checks, which is particularly
+useful for query builder expressions where `is [not] None` needs to
+trigger a TypeError.
+
+The approach is to re-parse the function's source and replace the
+identity checks with calls to methods via an ast.NodeTransformer.
+This avoids complex bytecode inspection or manipulation and preserves
+standard `is [not]` behavior for for objects that do not implement the
+`__gel_is__` or `__gel_is_not__` methods.
+"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+
+import ast
+import functools
+import inspect
+import textwrap
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
+
+def maybe_overload_is_operator(func: Callable[_P, _T]) -> Callable[_P, _T]:
+    """A decorator that overloads `is` and `is not` operators in a
+    function.
+
+    This decorator rewrites the function's bytecode to replace `is` and
+    `is not` operations with calls to `__gel_is__` and `__gel_is_not__`
+    on the left-hand operand.  This is done on a best effort basis, so
+    if there is any issue accessing function source or tranforming or
+    compiling it, the original function is returned unmodified.
+
+    Args:
+        func: The function to be transformed.
+
+    Returns:
+        The transformed function.
+    """
+    if not callable(func):
+        return func
+
+    if getattr(func, "__gel_is_overloaded__", False):
+        # Already transfomed.
+        return func
+
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        # If we can't get the source, we can't transform it, so
+        # return the original function.
+        return func
+
+    source = textwrap.dedent(source)
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # If parsing fails, return the original function.
+        return func
+
+    # `getsource` returns complete source lines, so if func is a
+    # lambda, it might be just a _substring_ of source, so traverse
+    # the AST until we find the first `def` or `lambda`.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.Lambda)):
+            func_tree = node
+            break
+    else:
+        # This should not happen if the source is from a valid function.
+        return func
+
+    # Transform the AST to replace `is` and `is not` operations.
+    transformer = _IsTransformer()
+    def_tree: ast.stmt = transformer.visit(func_tree)
+    if not transformer.num_transforms:
+        # No `is` or `is not` operations were found, so no changes
+        # are needed.
+        return func
+
+    # If the original function was a lambda, we need to assign it to a
+    # variable to be able to extract the newly compiled function object.
+    if isinstance(def_tree, ast.Lambda):
+        func_name = "__gel_lambda__"
+        def_tree = ast.Assign(
+            targets=[ast.Name(id=func_name, ctx=ast.Store())],
+            value=def_tree,
+        )
+    else:
+        func_name = func.__name__
+
+    tree = ast.Module(body=[def_tree], type_ignores=[])
+    ast.fix_missing_locations(tree)
+
+    try:
+        code = compile(tree, func.__code__.co_filename, "exec")
+    except Exception:
+        return func
+
+    # Reconstruct the closure namespace carefully.
+    closure_vars = inspect.getclosurevars(func)
+    globalns = {
+        **func.__globals__,
+        **closure_vars.globals,
+        **closure_vars.nonlocals,
+        "__gel_is__": _call_gel_is,
+        "__gel_is_not__": _call_gel_is_not,
+    }
+    try:
+        exec(code, globalns)  # noqa: S102
+    except Exception:
+        return func
+
+    # Grab the new function and transplant original's metadata onto it.
+    try:
+        new_func: Callable[_P, _T] = globalns[func_name]
+        new_func.__gel_is_overloaded__ = True  # type: ignore [attr-defined]
+        return functools.update_wrapper(new_func, func)
+    except Exception:
+        return func
+
+
+def _call_gel_is(obj: Any, other: Any) -> Any:
+    """A helper function that is called instead of `is`.
+
+    It tries to call `__gel_is__` on the object, and falls back to the
+    standard `is` operator if the method is not defined.
+    """
+    if callable(gel_is := getattr(obj, "__gel_is__", None)):
+        return gel_is(other)
+    else:
+        return obj is other
+
+
+def _call_gel_is_not(obj: Any, other: Any) -> Any:
+    """A helper function that is called instead of `is not`.
+
+    It tries to call `__gel_is_not__` on the object, and falls back to
+    the standard `is not` operator if the method is not defined.
+    """
+    if callable(gel_is_not := getattr(obj, "__gel_is_not__", None)):
+        return gel_is_not(other)
+    elif callable(gel_is := getattr(obj, "__gel_is__", None)):
+        return not gel_is(other)
+    else:
+        return obj is not other
+
+
+class _IsTransformer(ast.NodeTransformer):
+    """An AST transformer that replaces `is` and `is not` operations.
+
+    This transformer replaces `is` and `is not` operations with calls
+    to `__gel_is__` and `__gel_is_not__` respectively. This allows us to
+    overload these operators for our own objects.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._num_transforms = 0
+
+    @property
+    def num_transforms(self) -> int:
+        """The total number of `is` and `is not` operations that were
+        replaced.
+        """
+        return self._num_transforms
+
+    def visit_Compare(self, node: ast.Compare) -> ast.AST:  # noqa: N802
+        """Visit a `Compare` node and transform `is` and `is not`
+        operations.
+        """
+        # Recursively transform any nested nodes first.
+        self.generic_visit(node)
+
+        # We only care about simple comparisons with a single operator.
+        if len(node.ops) == 1 and len(node.comparators) == 1:
+            op = node.ops[0]
+            if isinstance(op, ast.Is):
+                # Replace `x is y` with `__gel_is__(x, y)`.
+                self._num_transforms += 1
+                return ast.Call(
+                    func=ast.Name(id="__gel_is__", ctx=ast.Load()),
+                    args=[node.left, node.comparators[0]],
+                    keywords=[],
+                )
+            elif isinstance(op, ast.IsNot):
+                # Replace `x is not y` with `__gel_is_not__(x, y)`.
+                self._num_transforms += 1
+                return ast.Call(
+                    func=ast.Name(id="__gel_is_not__", ctx=ast.Load()),
+                    args=[node.left, node.comparators[0]],
+                    keywords=[],
+                )
+
+        # Return the node unchanged if it's not a simple `is` or `is
+        # not` comparison.
+        return node

--- a/gel/_internal/_qb/_protocols.py
+++ b/gel/_internal/_qb/_protocols.py
@@ -18,6 +18,7 @@ from typing_extensions import TypeAliasType, TypeIs
 from collections.abc import Callable
 
 from gel._internal import _utils
+from gel._internal import _is_overload
 
 from ._abstract import Expr, ScopeContext
 
@@ -131,6 +132,11 @@ def edgeql_qb_expr(
     as_expr = getattr(x, "__edgeql_qb_expr__", None)
     if as_expr is None or not callable(as_expr):
         if is_expr_closure(x):
+            # Transform identity checks before evaluating the closure
+            # so that we can raise a TypeError on invalid uses of
+            # `expr is None`.
+            x = _is_overload.maybe_overload_is_operator(x)
+
             if var is None:
                 raise ValueError(
                     "edgeql_qb_expr: must specify *var* when evaluating "

--- a/gel/_internal/_qbmodel/_pydantic/_utils.py
+++ b/gel/_internal/_qbmodel/_pydantic/_utils.py
@@ -143,6 +143,7 @@ def model_dump_json_signature(
     self: BaseModel,
     *,
     indent: int | None = None,
+    ensure_ascii: bool = False,
     include: IncEx | None = None,
     exclude: IncEx | None = None,
     context: GelDumpContext | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ module = [
     "gel._internal._qbmodel._pydantic.*",
     "tests.test_dataclass_extras",
     "tests.test_dis_bool",
+    "tests.test_is_overload",
     "tests.test_parametric",
 ]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,13 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    'mypy>=1.17.0',
+    # Typecheckers and linters must be pinned exactly
+    # to avoid cqa breakage in CI.
+    'mypy==1.17.0',
+    'pyright==1.1.403',
+    'ruff==0.12.4',
+
     'pytest>=3.6.0',
-    'pyright>=1.1.400',
-    'ruff>=0.12.0',
     'uvloop>=0.15.1; platform_system != "Windows"',
     'fastapi',
     'pyjwt',

--- a/tests/test_is_overload.py
+++ b/tests/test_is_overload.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from gel._internal._is_overload import maybe_overload_is_operator
+
+
+class Overloadable:
+    """A test class that implements `__gel_is__` and `__gel_is_not__`."""
+
+    def __init__(self, is_result: bool, is_not_result: bool) -> None:
+        self._is_result = is_result
+        self._is_not_result = is_not_result
+        self.is_called_with: Any = None
+        self.is_not_called_with: Any = None
+
+    def __gel_is__(self, other: Any) -> bool:
+        self.is_called_with = other
+        return self._is_result
+
+    def __gel_is_not__(self, other: Any) -> bool:
+        self.is_not_called_with = other
+        return self._is_not_result
+
+
+class OverloadableIsOnly:
+    """A test class that only implements `__gel_is__`."""
+
+    def __init__(self, is_result: bool) -> None:
+        self._is_result = is_result
+        self.is_called_with: Any = None
+
+    def __gel_is__(self, other: Any) -> bool:
+        self.is_called_with = other
+        return self._is_result
+
+
+class TestIsOverload(unittest.TestCase):
+    def test_overload_is_with_function(self) -> None:
+        """Test that `is` and `is not` are overloaded in a regular
+        function."""
+        obj = Overloadable(is_result=True, is_not_result=False)
+
+        @maybe_overload_is_operator
+        def check_is(o: Any) -> bool:
+            return o is None
+
+        @maybe_overload_is_operator
+        def check_is_not(o: Any) -> bool:
+            return o is not None
+
+        # Check `is` overload
+        self.assertTrue(check_is(obj))
+        self.assertIsNone(obj.is_not_called_with)
+        self.assertIs(obj.is_called_with, None)
+
+        # Check `is not` overload
+        self.assertFalse(check_is_not(obj))
+        self.assertIs(obj.is_not_called_with, None)
+
+    def test_overload_is_with_lambda(self) -> None:
+        """Test that `is` and `is not` are overloaded in a lambda."""
+        obj = Overloadable(is_result=False, is_not_result=True)
+        sentinel = "something"
+
+        check_is = maybe_overload_is_operator(lambda o: o is sentinel)
+        check_is_not = maybe_overload_is_operator(lambda o: o is not sentinel)
+
+        # Check `is` overload
+        self.assertFalse(check_is(obj))
+        self.assertIsNone(obj.is_not_called_with)
+        self.assertIs(obj.is_called_with, sentinel)
+
+        # Reset and check `is not` overload
+        obj.is_called_with = None
+        self.assertTrue(check_is_not(obj))
+        self.assertIsNone(obj.is_called_with)
+        self.assertIs(obj.is_not_called_with, sentinel)
+
+    def test_overload_is_not_fallback_to_is(self) -> None:
+        """Test that `is not` falls back to `not __gel_is__` if
+        `__gel_is_not__` is not defined."""
+        obj = OverloadableIsOnly(is_result=True)
+        sentinel = 123
+
+        @maybe_overload_is_operator
+        def check_is_not(o: Any) -> bool:
+            return o is not sentinel
+
+        self.assertFalse(check_is_not(obj))
+        self.assertIs(obj.is_called_with, sentinel)
+
+    def test_overload_is_no_overload_methods(self) -> None:
+        """Test that standard `is` and `is not` behavior is preserved
+        for objects that don't have overload methods."""
+        obj = object()
+
+        @maybe_overload_is_operator
+        def check_is(o: Any) -> bool:
+            return o is obj
+
+        @maybe_overload_is_operator
+        def check_is_not(o: Any) -> bool:
+            return o is not obj
+
+        self.assertTrue(check_is(obj))
+        self.assertFalse(check_is_not(obj))
+        self.assertFalse(check_is(object()))
+        self.assertTrue(check_is_not(object()))
+
+    def test_overload_is_no_is_operations(self) -> None:
+        """Test that the decorator returns the original function if it
+        contains no `is` or `is not` operations."""
+        original_func = lambda x: x + 1  # noqa: E731
+
+        transformed_func = maybe_overload_is_operator(original_func)
+
+        # The function object itself should be returned, not a new one.
+        self.assertIs(original_func, transformed_func)
+        self.assertEqual(transformed_func(1), 2)
+
+    def test_overload_is_function_with_closure(self) -> None:
+        """Test that the decorator correctly handles functions with
+        closures."""
+        y = 10
+        obj = Overloadable(is_result=True, is_not_result=False)
+
+        @maybe_overload_is_operator
+        def check_is_with_closure(x: Any) -> bool:
+            # This function uses `y` from the enclosing scope.
+            return x is y
+
+        self.assertTrue(check_is_with_closure(obj))
+        self.assertIs(obj.is_called_with, y)
+
+    def test_overload_is_chained_comparison_is_not_transformed(self) -> None:
+        """Test that chained comparisons are not transformed."""
+
+        # The transformer should not modify chained comparisons because
+        # they have more than one operator. The original function should
+        # be returned.
+        def chained(a: Any, b: Any, c: Any) -> bool:
+            return a is b is c
+
+        transformed_chained = maybe_overload_is_operator(chained)
+        self.assertIs(chained, transformed_chained)
+
+        obj1 = object()
+        obj2 = object()
+        self.assertTrue(transformed_chained(obj1, obj1, obj1))
+        self.assertFalse(transformed_chained(obj1, obj1, obj2))
+
+    def test_overload_is_unsupported_object_returns_original_function(
+        self,
+    ) -> None:
+        """Test that the decorator returns the original function if it
+        can't get the source code."""
+        # `int` is a C-defined type, so inspect.getsource will fail.
+        original_func = int
+        transformed_func = maybe_overload_is_operator(original_func)
+        self.assertIs(original_func, transformed_func)
+
+    def test_overload_is_syntax_error_returns_original_function(self) -> None:
+        """Test that the decorator returns the original function if
+        there's a syntax error in parsing."""
+
+        # This test simulates what happens when source code can't be
+        # parsed. We'll create a function normally and then test it.
+        def normal_func(x: Any) -> bool:
+            return x is None
+
+        # The function should work normally
+        transformed_func = maybe_overload_is_operator(normal_func)
+        obj = Overloadable(is_result=True, is_not_result=False)
+        self.assertTrue(transformed_func(obj))
+        self.assertIs(obj.is_called_with, None)
+
+    def test_overload_is_non_callable_returns_as_is(self) -> None:
+        """Test that the decorator returns non-callable objects as-is."""
+        not_callable = 42
+        result = maybe_overload_is_operator(not_callable)  # type: ignore [arg-type, var-annotated]
+        self.assertIs(result, not_callable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qb.py
+++ b/tests/test_qb.py
@@ -509,11 +509,19 @@ class TestQueryBuilder(tb.ModelTestCase):
 
         # Test that using '== None' comparison raises TypeError
         with self.assertRaisesRegex(TypeError, r"use std.not_\(std.exists"):
-            default.User.filter(lambda u: u.name == None)  # type: ignore [arg-type, return-value]  # noqa: E711
+            default.User.filter(lambda u: u.name == None)  # type: ignore  # noqa: E711
 
         # Test that using '!= None' comparison raises TypeError
         with self.assertRaisesRegex(TypeError, "use std.exists"):
-            default.User.filter(lambda u: u.name != None)  # type: ignore [arg-type, return-value]  # noqa: E711
+            default.User.filter(lambda u: u.name != None)  # type: ignore  # noqa: E711
+
+        # Test that using 'is None' comparison raises TypeError
+        with self.assertRaisesRegex(TypeError, r"use std.not_\(std.exists"):
+            default.User.filter(lambda u: u.name is None)  # type: ignore
+
+        # Test that using 'is not None' comparison raises TypeError
+        with self.assertRaisesRegex(TypeError, "use std.exists"):
+            default.User.filter(lambda u: u.name is not None)  # type: ignore
 
 
 class TestQueryBuilderModify(tb.ModelTestCase):


### PR DESCRIPTION
Similarly to prohibiting `<expr> == None`, raise on `<expr> is None`
is used.  Unlike boolean ops, there is no idiomatic way of intercepting
identity checks, so we have to resort to AST rewrites, which limits the
scope of where the protection applies to lambdas in query builder
expreesssions.

Follow up to PR #799 (issue #780).
