### PR TITLE
Apply generate config from env

### DIFF
--- a/gel/_internal/_codegen/_generator.py
+++ b/gel/_internal/_codegen/_generator.py
@@ -127,11 +127,14 @@ class AbstractCodeGenerator:
                                 f"{C.BLUE}{no + 1:>{left}} | {C.ENDC}"
                                 f"{line.rstrip()}"
                             )
-                            l = max(0, start - offset)
-                            r = min(llen - l, end - offset - l)
+                            n_spaces = max(0, start - offset)
+                            mark_len = min(
+                                llen - n_spaces, end - offset - n_spaces
+                            )
                             self.print_msg(
                                 f"{'':>{left}}{C.BLUE} | {C.ENDC}"
-                                f"{'':>{l}}{C.FAIL}{'':^>{r}}{C.ENDC}"
+                                f"{'':>{n_spaces}}"
+                                f"{C.FAIL}{'':^>{mark_len}}{C.ENDC}"
                             )
                             if offset < end < offset + llen:
                                 break

--- a/gel/codegen/cli.py
+++ b/gel/codegen/cli.py
@@ -52,7 +52,7 @@ def _get_base_parser(description: str) -> ColoredArgumentParser:
         "--tls-security",
         choices=["default", "strict", "no_host_verification", "insecure"],
     )
-    parser.add_argument("--no-cache", action="store_true")
+    parser.add_argument("--no-cache", action="store_true", default=None)
     parser.add_argument("--quiet", action="store_true")
     return parser
 


### PR DESCRIPTION
Parse and apply generate config from environment variables, see also geldata/gel-cli#1703.

This PR adds the infrastructure to parse generate config envs and report errors, as well as 2 configs for the `models` generator:

* `no_cache`: boolean, the same as `--no-cache`
* `output`: string, the same as `--output`

Parse error looks like:

<img width="1032" height="193" alt="image" src="https://github.com/user-attachments/assets/1bb0fdcb-8c93-4880-afa3-2b56ab2b482b" />
