### PR TITLE
models: Make ids less magic

### DIFF
--- a/gel/_internal/_qbmodel/_abstract/_base.py
+++ b/gel/_internal/_qbmodel/_abstract/_base.py
@@ -147,7 +147,7 @@ class AbstractGelModelMeta(GelTypeMeta):
         namespace: dict[str, Any],
         *,
         __gel_type_id__: uuid.UUID | None = None,
-        __gel_variant__: str | None = None,
+        __gel_shape__: str | None = None,
         **kwargs: Any,
     ) -> AbstractGelModelMeta:
         cls = cast(
@@ -156,7 +156,7 @@ class AbstractGelModelMeta(GelTypeMeta):
         )
         if __gel_type_id__ is not None:
             mcls.__gel_class_registry__[__gel_type_id__] = cls
-        cls.__gel_variant__ = __gel_variant__
+        cls.__gel_shape__ = __gel_shape__
         return cls
 
     @classmethod
@@ -181,12 +181,12 @@ class AbstractGelModel(
     _qb.GelObjectTypeMetadata,
     metaclass=AbstractGelModelMeta,
 ):
-    __gel_variant__: ClassVar[str | None] = None
+    __gel_shape__: ClassVar[str | None] = None
     """Auto-reflected model variant marker."""
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
-        cls.__gel_variant__ = None
+        cls.__gel_shape__ = None
 
     @classmethod
     def __edgeql_qb_expr__(cls) -> _qb.Expr:  # pyright: ignore [reportIncompatibleMethodOverride]
@@ -240,7 +240,7 @@ def maybe_collapse_object_type_variant_union(
         elif typename != union_arg.__gel_reflection__.name:
             # Reflections of different object types, cannot collapse.
             return None
-        if union_arg.__gel_variant__ == "Default" and default_variant is None:
+        if union_arg.__gel_shape__ == "Default" and default_variant is None:
             default_variant = union_arg
 
     return default_variant

--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -79,30 +79,30 @@ class GelModelMeta(
         namespace: dict[str, Any],
         *,
         __gel_type_id__: uuid.UUID | None = None,
-        __gel_variant__: str | None = None,
+        __gel_shape__: str | None = None,
         __gel_root_class__: bool = False,
         **kwargs: Any,
     ) -> GelModelMeta:
-        if __gel_variant__ is None:
+        if __gel_shape__ is None:
             # This is to make the top-level reflection of user-defined
-            # types look less noisy. `__gel_variant__` is inferred from
-            # the top-level __gel_default_variant__ attribute of the module
+            # types look less noisy. `__gel_shape__` is inferred from
+            # the top-level __gel_default_shape__ attribute of the module
             # where the class is defined.
             #
             # This adds a negligible overhead to class creation, but:
             # we only do this for user-defined schema (std has explicit
-            # __gel_variant__ class argument everywhere), and there shouldn't
+            # __gel_shape__ class argument everywhere), and there shouldn't
             # be so many of user-defined Python subclasses for this to become
             # an issue.
             module = namespace.get("__module__")
             if (
                 module
                 and (mod := sys.modules.get(module))
-                and (v := getattr(mod, "__gel_default_variant__", _unset))
+                and (v := getattr(mod, "__gel_default_shape__", _unset))
                 is not _unset
             ):
                 assert isinstance(v, str)
-                __gel_variant__ = v
+                __gel_shape__ = v
 
         with warnings.catch_warnings():
             # Make pydantic shut up about attribute redefinition.
@@ -116,7 +116,7 @@ class GelModelMeta(
                     mcls,
                     name,
                     bases,
-                    namespace | {"__gel_variant__": __gel_variant__},
+                    namespace | {"__gel_shape__": __gel_shape__},
                     **kwargs,
                 ),
             )
@@ -126,6 +126,10 @@ class GelModelMeta(
         cls.__pydantic_decorators__.computed_fields = {
             **cls.__gel_cached_decorator_fields__,
             **cls.__pydantic_decorators__.computed_fields,
+        }
+        cls.__pydantic_computed_fields__ = {
+            k: v.info
+            for k, v in cls.__pydantic_decorators__.computed_fields.items()
         }
         del cls.__gel_cached_decorator_fields__
 
@@ -176,7 +180,12 @@ class GelModelMeta(
         if __gel_type_id__ is not None:
             mcls.register_class(__gel_type_id__, cls)
 
-        cls.__gel_variant__ = __gel_variant__
+        cls.__gel_shape__ = __gel_shape__
+
+        if not __gel_root_class__:
+            cls.__gel_id_shape__ = _determine_gel_id_shape(cls)
+        else:
+            cls.__gel_id_shape__ = None
 
         return cls
 
@@ -254,9 +263,14 @@ class GelModelMeta(
             # the metaclass, right after the call to
             # `super().__new__()`.
             assert isinstance(value, _decorators.DecoratorInfos)
-            ll_type_setattr(
-                cls, "__gel_cached_decorator_fields__", value.computed_fields
-            )
+            # Pydantic sets __pydantic_decorators__ at least twice
+            # in __new__ (to the same value).
+            if not hasattr(cls, "__gel_cached_decorator_fields__"):
+                ll_type_setattr(
+                    cls,
+                    "__gel_cached_decorator_fields__",
+                    value.computed_fields,
+                )
             value.computed_fields = {}
             ll_type_setattr(cls, name, value)
 
@@ -305,9 +319,8 @@ def _resolve_pointers(cls: type[GelSourceModel]) -> dict[str, type[GelType]]:
     ):
         descriptor = inspect.getattr_static(cls, ptr_name)
         if not isinstance(descriptor, _abstract.ModelFieldDescriptor):
-            raise AssertionError(
-                f"'{cls}.{ptr_name}' is not a ModelFieldDescriptor"
-            )
+            # This is a regular Pydantic computed_field
+            continue
         t = descriptor.get_resolved_type()
         if t is None:
             raise TypeError(
@@ -333,6 +346,36 @@ def _resolve_pointers(cls: type[GelSourceModel]) -> dict[str, type[GelType]]:
         pointers[ptr_name] = t
 
     return pointers
+
+
+_ID_SHAPES = frozenset(("NoId", "OptionalId", "RequiredId"))
+
+
+def _determine_gel_id_shape(cls: type[GelModel]) -> str | None:
+    if cls.__gel_shape__ == "Base":
+        return None
+    elif cls.__gel_shape__ in _ID_SHAPES:
+        return cls.__gel_shape__
+    else:
+        id_shape: tuple[str, str] | None = None
+        for base in cls.__bases__:
+            base_id_shape = getattr(base, "__gel_id_shape__", None)
+            if base_id_shape is not None:
+                if id_shape is None:
+                    id_shape = (base_id_shape, base.__qualname__)
+                elif id_shape[0] != base_id_shape:
+                    raise TypeError(
+                        f"cannot inherit from {id_shape[1]} and "
+                        f"{base.__qualname__} simultaneously: "
+                        f"{id_shape[1]} is a {id_shape[0]} shape while "
+                        f"{base.__qualname__} is a {base_id_shape} shape "
+                        f"which are mutually incompatible"
+                    )
+
+        if id_shape is None:
+            return None
+        else:
+            return id_shape[0]
 
 
 _NO_DEFAULT = frozenset({pydantic_core.PydanticUndefined, None})
@@ -483,7 +526,7 @@ def _process_pydantic_fields(
         # This is a schema computed or an ad-hoc computed pointer in a
         # user-defined variant.
         if pointer_info.computed or (
-            cls.__gel_variant__ is None
+            cls.__gel_shape__ is None
             and ptr is None
             and fn != "__linkprops__"
         ):
@@ -587,6 +630,13 @@ class GelSourceModel(
 
         # Whether the model uses DEFAULT_MODEL_CONFIG or not.
         __gel_default_model_config__: ClassVar[bool]
+
+        # Explicitly declared shape for this model
+        __gel_shape__: ClassVar[str | None]
+
+        # Which Id shape this model inherits from.  Determines handling of
+        # the id property.
+        __gel_id_shape__: ClassVar[str | None]
 
     @classmethod
     def __gel_model_construct__(cls, __dict__: dict[str, Any] | None) -> Self:
@@ -870,7 +920,6 @@ class GelModel(
     __gel_has_id_field__: ClassVar[bool] = True
 
     if TYPE_CHECKING:
-        id: uuid.UUID
         __gel_new__: bool
         __gel_custom_serializer__: ClassVar[pydantic_core.SchemaSerializer]
 
@@ -932,22 +981,33 @@ class GelModel(
         id: uuid.UUID = UNSET_UUID,  # noqa: A002
         **kwargs: Any,
     ) -> None:
-        if id is not UNSET_UUID:
-            if self.__dict__.get("id", _unset) is _unset:
+        has_id_field = "id" in type(self).__pydantic_fields__
+        if has_id_field:
+            if id is not UNSET_UUID:
+                if self.__dict__.get("id", _unset) is _unset:
+                    raise ValueError(
+                        "models do not support setting `id` on construction; "
+                        "`id` is set automatically by the `client.save()` method"
+                    )
+                else:
+                    # The object was created and initialized by __new__,
+                    # nothing to do in `__init__`.
+                    return
+
+            super().__init__(id=id, **kwargs)
+
+            # UNSET_UUID is a transient value, it must not leak to user code.
+            marker = self.__dict__.pop("id")
+            assert marker is UNSET_UUID
+        else:
+            if id is not UNSET_UUID:
                 raise ValueError(
-                    "models do not support setting `id` on construction; "
-                    "`id` is set automatically by the `client.save()` method"
+                    f"unexpecged `id` argument to constructor of "
+                    f"{type(self).__qualname__}, which is a "
+                    f"{type(self).__gel_id_shape__} shape"
                 )
-            else:
-                # The object was created and initialized by __new__,
-                # nothing to do in `__init__`.
-                return
 
-        super().__init__(id=id, **kwargs)
-
-        # UNSET_UUID is a transient value, it must not leak to user code.
-        marker = self.__dict__.pop("id")
-        assert marker is UNSET_UUID
+            super().__init__(**kwargs)
 
         self.__gel_new__ = True
 
@@ -1009,7 +1069,7 @@ class GelModel(
                     f"cannot set id on {self!r} after it has been set"
                 )
             self.__gel_new__ = False
-            ll_setattr(self, "id", new_id)
+            self.__dict__["id"] = new_id
 
         assert not self.__gel_new__
         super().__gel_commit__()
@@ -1065,7 +1125,10 @@ class GelModel(
         if self.__gel_new__ or other_obj.__gel_new__:
             return False
 
-        return self.id == other_obj.id
+        if not self.__gel_id_shape__ or not other_obj.__gel_id_shape__:
+            return False
+
+        return self.id == other_obj.id  # type: ignore [no-any-return]
 
     def __hash__(self) -> int:
         if self.__gel_new__:
@@ -1270,7 +1333,11 @@ class _MergedModelMeta(GelModelMeta):
         super().__setattr__(name, value)
 
 
-class _MergedModelBase(GelModel, metaclass=_MergedModelMeta):
+class _MergedModelBase(
+    GelModel,
+    metaclass=_MergedModelMeta,
+    __gel_root_class__=True,
+):
     # Used exclusively by ProxyModel.__gel_proxy_make_merged_model__.
     if TYPE_CHECKING:
         __gel_new__: bool
@@ -1327,7 +1394,6 @@ class ProxyModel(
     def __init__(
         self,
         /,
-        id: uuid.UUID = UNSET_UUID,  # noqa: A002
         *,
         __linkprops__: Any = _unset,
         **kwargs: Any,
@@ -1338,7 +1404,7 @@ class ProxyModel(
 
         # We want ProxyModel to be a trasparent wrapper, so we
         # forward the constructor arguments to the wrapped object.
-        wrapped = self.__proxy_of__(id, **kwargs)
+        wrapped = self.__proxy_of__(**kwargs)
         ll_setattr(self, "_p__obj__", wrapped)
         # __linkprops__ is written into __dict__ by GelLinkModelDescriptor
 
@@ -1566,7 +1632,10 @@ class ProxyModel(
         if self_obj.__gel_new__ or other_obj.__gel_new__:
             return False
 
-        return self_obj.id == other_obj.id
+        if not self.__gel_id_shape__ or not other_obj.__gel_id_shape__:
+            return False
+
+        return self_obj.id == other_obj.id  # type: ignore [no-any-return]
 
     def __hash__(self) -> int:
         wrapped = ll_getattr(self, "_p__obj__")

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -246,6 +246,13 @@ class ObjectType(InheritingType):
     compound_type: bool
     pointers: tuple[Pointer, ...]
 
+    def get_pointer(self, name: str) -> Pointer:
+        for ptr in self.pointers:
+            if ptr.name == name:
+                return ptr
+
+        raise LookupError(f"object type {self.name} has no pointer {name}")
+
 
 class CollectionType(Type):
     @functools.cached_property

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -1147,7 +1147,7 @@ class SaveExecutor:
         if obj.__gel_new__:
             return self.object_ids[id(obj)]
         else:
-            return obj.id
+            return obj.id  # type: ignore [no-any-return]
 
     def _compile_change(
         self, change: ModelChange, /, *, for_insert: bool

--- a/gel/protocol/codecs/object.pyx
+++ b/gel/protocol/codecs/object.pyx
@@ -401,10 +401,14 @@ cdef class ObjectCodec(BaseNamedRecordCodec):
                 subs.append(None)
                 dlists.append(None)
                 origins.append(return_type)
-            elif name in {"__tname__", "__tid__"}:
+            elif name == "__tid__":
                 subs.append(None)
                 dlists.append(None)
                 self.cached_tid_index = i
+                origins.append(return_type)
+            elif name in {"__tname__", "id"}:
+                subs.append(None)
+                dlists.append(None)
                 origins.append(return_type)
             else:
                 origin = return_type

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -4331,6 +4331,94 @@ class TestModelGenerator(tb.ModelTestCase):
             ),
         )
 
+    def test_modelgen_json_schema_2(self):
+        # Test the behavior of id shapes
+
+        import textwrap
+        import json
+
+        from models import default
+        from gel._testbase_schema import render_schema_from_json
+
+        class CreateUser(default.User.__shapes__.Create):
+            pass
+
+        schema = render_schema_from_json(
+            json.dumps(
+                CreateUser.model_json_schema(mode="validation"),
+                indent=2,
+            )
+        )
+
+        self.assertEqual(
+            schema.strip(),
+            textwrap.dedent(
+                """\
+                class CreateUser:
+                    name: str
+                    nickname: None | str = None"""
+            ),
+        )
+
+        schema = render_schema_from_json(
+            json.dumps(
+                CreateUser.model_json_schema(mode="serialization"),
+                indent=2,
+            )
+        )
+
+        self.assertEqual(
+            schema.strip(),
+            textwrap.dedent(
+                """\
+                class CreateUser:
+                    groups: list[UserGroup]  # readonly
+                    id: UUID  # readonly
+                    name: str
+                    name_len: Any  # readonly
+                    nickname: None | str = None
+                    nickname_len: None | int  # readonly
+
+                class User:
+                    groups: list[UserGroup]  # readonly
+                    id: UUID
+                    name: str
+                    name_len: Any  # readonly
+                    nickname: None | str = None
+                    nickname_len: None | int  # readonly
+
+                class UserGroup:
+                    id: UUID
+                    mascot: None | str = None
+                    name: str
+                    name_len: Any  # readonly
+                    nickname: None | str = None
+                    nickname_len: None | int  # readonly
+                    users: list[User] = ..."""
+            ),
+        )
+
+        class UpdateUser(default.User.__shapes__.Update):
+            pass
+
+        schema = render_schema_from_json(
+            json.dumps(
+                UpdateUser.model_json_schema(mode="validation"),
+                indent=2,
+            )
+        )
+
+        self.assertEqual(
+            schema.strip(),
+            textwrap.dedent(
+                """\
+                class UpdateUser:
+                    id: None | UUID = None
+                    name: None | str = None
+                    nickname: None | str = None"""
+            ),
+        )
+
     def test_modelgen_function_overloads_01(self):
         """Test basic function overloads with different parameter types"""
         from models import default


### PR DESCRIPTION
Second part of implementing #805, turns `id` of the `NoId`, `RequiredId`
and `OptionalId` shapes into a well-behaved Pydantic field so that
schemas are happy.
