### PR TITLE
fastapi: start SMTP server for testing

### DIFF
--- a/gel/_internal/_integration/_fastapi/_cli/_patch.py
+++ b/gel/_internal/_integration/_fastapi/_cli/_patch.py
@@ -20,24 +20,24 @@ def _get_fastapi_cli_import_site() -> types.FrameType | None:
     return None
 
 
-def maybe_patch_fastapi_cli() -> None:
+def maybe_patch_fastapi_cli() -> bool:
     if importlib.util.find_spec("fastapi") is None:
         # No FastAPI here, move along.
-        return
+        return False
 
     try:
         import uvicorn  # noqa: PLC0415  # pyright: ignore [reportMissingImports]
     except ImportError:
-        return
+        return False
 
     fastapi_cli_import_site = _get_fastapi_cli_import_site()
     if fastapi_cli_import_site is None:
         # Not being imported by fastapi.cli
-        return
+        return False
 
     if fastapi_cli_import_site.f_locals.get("command") != "dev":
         # Don't patch in production mode.
-        return
+        return False
 
     def _patched_uvicorn_run(*args: Any, **kwargs: Any) -> None:
         from . import _lifespan  # noqa: PLC0415
@@ -62,3 +62,4 @@ def maybe_patch_fastapi_cli() -> None:
         uvicorn.__name__,
         doc=uvicorn.__doc__,
     )
+    return True

--- a/gel/_internal/_integration/_fastapi/_cli/_patch.py
+++ b/gel/_internal/_integration/_fastapi/_cli/_patch.py
@@ -35,6 +35,10 @@ def maybe_patch_fastapi_cli() -> None:
         # Not being imported by fastapi.cli
         return
 
+    if fastapi_cli_import_site.f_locals.get("command") != "dev":
+        # Don't patch in production mode.
+        return
+
     def _patched_uvicorn_run(*args: Any, **kwargs: Any) -> None:
         from . import _lifespan  # noqa: PLC0415
 

--- a/gel/_internal/_integration/_fastapi/_cli/_smtpd.py
+++ b/gel/_internal/_integration/_fastapi/_cli/_smtpd.py
@@ -1,0 +1,162 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+import asyncio
+import email.message
+import email.parser
+import email.policy
+
+import gel
+from fastapi_cli.utils.cli import get_rich_toolkit
+
+if TYPE_CHECKING:
+    import rich_toolkit
+
+
+class SMTPServerProtocol(asyncio.Protocol):
+    _transport: asyncio.Transport
+    _mail_from: Optional[str]
+    _rcpt_to: list[str]
+    _parser: email.parser.BytesFeedParser
+    _in_data: bool = False
+
+    def __init__(self, cli: rich_toolkit.RichToolkit):
+        self._cli = cli
+        self._buffer = bytearray()
+        self._reset()
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        assert isinstance(transport, asyncio.Transport)
+        self._transport = transport
+        transport.write(b"220 localhost Simple SMTP server\r\n")
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        del self._transport
+
+    def data_received(self, data: bytes) -> None:
+        self._buffer.extend(data)
+
+        while True:
+            newline_index = self._buffer.find(b"\r\n")
+            if newline_index == -1:
+                break
+
+            line = self._buffer[:newline_index]
+            self._buffer = self._buffer[newline_index + 2 :]
+
+            self._handle_line(bytes(line))
+
+    def _handle_line(self, line: bytes) -> None:
+        if self._in_data:
+            if line == b".":  # End of DATA mode
+                message = self._parser.close()
+                assert isinstance(message, email.message.EmailMessage)
+                self._handle_message(message)
+                self._reset()
+                self._transport.write(b"250 OK\r\n")
+            else:
+                self._parser.feed(line + b"\r\n")
+            return
+
+        # Handle SMTP commands
+        upper = line.upper()
+        if upper.startswith((b"HELO", b"EHLO")):
+            self._transport.write(b"250 Hello\r\n")
+        elif upper.startswith(b"MAIL FROM:"):
+            self._mail_from = line[10:].strip().decode()
+            self._transport.write(b"250 OK\r\n")
+        elif upper.startswith(b"RCPT TO:"):
+            self._rcpt_to.append(line[8:].strip().decode())
+            self._transport.write(b"250 OK\r\n")
+        elif upper == b"DATA":
+            self._transport.write(b"354 End data with <CR><LF>.<CR><LF>\r\n")
+            self._in_data = True
+        elif upper == b"QUIT":
+            self._transport.write(b"221 Bye\r\n")
+            self._transport.close()
+        else:
+            self._transport.write(b"500 Unrecognized command\r\n")
+
+    def _handle_message(self, message: email.message.EmailMessage) -> None:
+        self._cli.print("Received email:", tag="gel")
+        self._cli.print(f"  From: {self._mail_from}", tag="gel")
+        self._cli.print(f"  To: {', '.join(self._rcpt_to)}", tag="gel")
+        self._cli.print(f"  Subject: {message.get('Subject')}", tag="gel")
+        for key in message:
+            if key.lower().startswith("x-gel-"):
+                self._cli.print(f"  {key}: {message[key]}", tag="gel")
+
+    def _reset(self) -> None:
+        self._mail_from = None
+        self._rcpt_to = []
+        self._parser = email.parser.BytesFeedParser(policy=email.policy.SMTP)
+        self._in_data = False
+        self._buffer.clear()
+
+
+class SMTPServer:
+    _server: asyncio.Server
+
+    async def maybe_start(
+        self,
+        client: gel.AsyncIOClient,
+    ) -> None:
+        with get_rich_toolkit() as toolkit:
+            try:
+                config = await client.query_single("""
+                    select cfg::SMTPProviderConfig {
+                        host,
+                        port,
+                        security
+                    } filter .name =
+                        assert_single(cfg::Config).current_email_provider_name;
+                """)
+            except gel.QueryError as ex:
+                toolkit.print(
+                    f"Skipping SMTP server startup due to "
+                    f"error reading configuration: {ex}",
+                    tag="gel",
+                )
+                return None
+
+            if config is None:
+                toolkit.print(
+                    "No SMTP configuration found, "
+                    "skipping SMTP server startup",
+                    tag="gel",
+                )
+                return None
+            if config.security not in {"PlainText", "STARTTLSOrPlainText"}:
+                toolkit.print(
+                    "SMTP server only supports security=PlainText or "
+                    "STARTTLSOrPlainText, skipping SMTP server startup",
+                    tag="gel",
+                )
+                return None
+
+            try:
+                self._server = await asyncio.get_running_loop().create_server(
+                    lambda: SMTPServerProtocol(toolkit),
+                    host=config.host,
+                    port=config.port,
+                )
+            except Exception as ex:
+                toolkit.print(
+                    f"Skipping SMTP server startup due to error: {ex}",
+                    tag="gel",
+                )
+            else:
+                toolkit.print(
+                    f"Started SMTP server on {config.host}:{config.port} "
+                    f"for testing purposes.",
+                    tag="gel",
+                )
+
+    async def stop(self) -> None:
+        if hasattr(self, "_server"):
+            self._server.close()
+            await self._server.wait_closed()


### PR DESCRIPTION
If:

1. The Gel server has a plaintext-compatible SMTP server configured
2. Starting gelified FastAPI application with `fastapi dev`

This PR will try to start an SMTP server that simply logs received emails (just basic info + `X-gel-*` headers, see also geldata/gel#8919), at the configured host and port; it will recover with a warning if the SMTP server cannot be started for any reason.

<img width="2780" height="652" alt="image" src="https://github.com/user-attachments/assets/e99f619f-a4a4-4167-9273-e5805d282672" />

So that the user could test the email function without the trouble to set up a local SMTP server.