### PR TITLE
Make sync() populate objects with same .id with the same set of fields

### DIFF
--- a/gel/_internal/_qbmodel/_abstract/__init__.py
+++ b/gel/_internal/_qbmodel/_abstract/__init__.py
@@ -40,6 +40,8 @@ from ._descriptors import (
     get_proxy_linkprops,
     is_proxy_linked,
     copy_or_ref_lprops,
+    reconcile_link,
+    reconcile_proxy_link,
 )
 
 from ._link_set import (
@@ -184,4 +186,6 @@ __all__ = (
     "is_generic_type",
     "is_proxy_linked",
     "maybe_get_protocol_for_py_type",
+    "reconcile_link",
+    "reconcile_proxy_link",
 )

--- a/gel/_internal/_tracked_list.py
+++ b/gel/_internal/_tracked_list.py
@@ -30,6 +30,7 @@ from collections.abc import (
     Sequence,
 )
 
+import copy
 import functools
 
 from gel._internal import _typing_inspect
@@ -253,6 +254,23 @@ class AbstractTrackedList(
         self._added_items = None
         self._removed_items = None
         super().__init__(*args, **kwargs)
+
+    def __copy__(self, *, deep: bool = False) -> Self:
+        obj = type(self).__new__(type(self))
+
+        obj.__gel_overwrite_data__ = self.__gel_overwrite_data__
+        obj._mode = self._mode
+        obj._items = copy.deepcopy(self._items) if deep else list(self._items)
+        obj._added_items = (
+            list(self._added_items) if self._added_items else None
+        )
+        obj._removed_items = (
+            list(self._removed_items) if self._removed_items else None
+        )
+        return obj
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> Self:
+        return self.__copy__(deep=True)
 
     def __gel_extend__(self, it: Iterable[_T_co]) -> None:
         self.extend(it)

--- a/gel/protocol/codecs/object.pyx
+++ b/gel/protocol/codecs/object.pyx
@@ -389,8 +389,7 @@ cdef class ObjectCodec(BaseNamedRecordCodec):
                 dlists.append(None)
                 self.cached_tname_index = i
                 origins.append(return_type)
-            elif name in {"__tid__", "id", "__py_id"}:
-                # __py_id is used by `save()`
+            elif name in {"__tid__", "id"}:
                 subs.append(None)
                 dlists.append(None)
                 origins.append(return_type)


### PR DESCRIPTION
* Currently sync() will track objects by their Python address, so if we have `alice1` with just `name` property, and we have `alice2` with the same `id` but only `email` property, after sync() they would only have their `.name` and `.email` properties updated respectively.

  We are changing sync() to populate them with the same data, so after sync() they would both have `.name` and `.email` attributes and their `.__dict__` would be equal.

  We do this because of computed backlinks (although I think we can find more motivation for this if we think hard). If `alice1` and `alice2` have the same `.id` and `alice1` was added to the `UserGroup.users` multi link, we want *both* `alice1.groups` and `alice2.groups` computeds to point back to the new user group they are member of. We also want to make it irrelevant if it was `alice1` or `alice2` added to `UserGroup.users` -- after sync() it shouldn't matter as they will both reflect the same data and be completely equivalent (albeit still two distinct Python objects, with distinct link set & multi props & mutable props collections!)

* LinkSet / LinkWithPropsSet / TrackedList get `__copy__` and `__deepcopy__` methods