### PR TITLE
Refactor tests to namespace generated schema into `models.{schema}`

### DIFF
--- a/gel/_testbase.py
+++ b/gel/_testbase.py
@@ -754,6 +754,10 @@ class BaseModelTestCase(DatabaseTestCase):
             td_kwargs["delete"] = not cls.orm_debug
 
         cls.tmp_model_dir = tempfile.TemporaryDirectory(**td_kwargs)
+
+        assert isinstance(cls.SCHEMA, str)
+        short_name = pathlib.Path(cls.SCHEMA).stem
+
         if cls.orm_debug:
             print(cls.tmp_model_dir.name)
 
@@ -766,7 +770,15 @@ class BaseModelTestCase(DatabaseTestCase):
         try:
             gen_client.ensure_connected()
             cls.gen = PydanticModelsGenerator(
-                argparse.Namespace(no_cache=True, quiet=True, output=None),
+                argparse.Namespace(
+                    no_cache=True,
+                    quiet=True,
+                    output=(
+                        pathlib.Path(cls.tmp_model_dir.name)
+                        / "models"
+                        / short_name
+                    ).absolute(),
+                ),
                 project_dir=pathlib.Path(cls.tmp_model_dir.name),
                 client=gen_client,
                 interactive=False,

--- a/tests/dbsetup/empty.gel
+++ b/tests/dbsetup/empty.gel
@@ -1,0 +1,1 @@
+# keep this file empty!

--- a/tests/test_async_model.py
+++ b/tests/test_async_model.py
@@ -20,7 +20,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
 
     @tb.must_fail  # this test ensures that @typecheck is working
     async def test_async_modelgen__smoke_test_01(self):
-        from models import default
+        from models.orm import default
 
         self.assertEqual(reveal_type(default.User.groups), "this must fail")
 
@@ -30,7 +30,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
         raise AssertionError("this must fail")
 
     async def test_async_modelgen_01(self):
-        from models import default
+        from models.orm import default
 
         alice = await self.client.query_required_single(
             default.User.select(
@@ -50,7 +50,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
     async def test_async_modelgen_02(self):
         import uuid
 
-        from models import default
+        from models.orm import default
         # insert an object with a required multi: no link props, one object
         # added to the link
 
@@ -80,7 +80,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
         self.assertEqual(m.nickname, "Hannibal")
 
     async def test_async_modelgen_save_refetch_modes(self):
-        from models import default
+        from models.orm import default
 
         u1 = default.User(name="Al")
         await self.client.sync(u1)
@@ -94,7 +94,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
         # This is a copy if test_async_modelgen_save_reload_links_07
         # ensuring the sync() is fully supported in async mode.
 
-        from models import default
+        from models.orm import default
 
         # Test backlink invalidation when adding a user to a different group
         # Fetch red and blue groups with nested user data and their groups
@@ -153,7 +153,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
         self.assertEqual({u.id for u in blue.users}, {alice.id})
 
     async def test_async_modelgen_sync_warning(self):
-        from models import default
+        from models.orm import default
 
         g = default.UserGroup(
             name="Pickle Pirates",

--- a/tests/test_async_model.py
+++ b/tests/test_async_model.py
@@ -41,7 +41,7 @@ class TestAsyncModelGenerator(tb.AsyncModelTestCase):
         )
 
         self.assertIn(
-            "ComputedLinkSet[models.default.UserGroup]",
+            "ComputedLinkSet[models.orm.default.UserGroup]",
             reveal_type(alice.groups),
         )
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -3622,7 +3622,7 @@ class TestModelGenerator(tb.ModelTestCase):
         # Test that sync() updates all objects with the same .id to have
         # the same data in them.
 
-        from models import default
+        from models.orm import default
 
         elsa1 = self.client.get(
             default.User.select(name=True).filter(lambda u: u.name == "Elsa"),

--- a/tests/test_qb.py
+++ b/tests/test_qb.py
@@ -33,7 +33,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     def test_qb_computed_01(self):
         """Replace an existing field with a computed literal value"""
-        from models import default, std
+        from models.orm import default, std
 
         res1 = self.client.get(
             default.User.select(
@@ -54,7 +54,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res2.nickname, "hello")
 
     def test_qb_computed_02(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.User.select(
@@ -67,7 +67,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_computed_03(self):
-        from models import default, std
+        from models.orm import default, std
 
         res = self.client.get(
             default.User.select(
@@ -79,7 +79,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res.nickname, "Alice5")
 
     def test_qb_computed_04(self):
-        from models import default, std
+        from models.orm import default, std
 
         class MyUser(default.User):
             foo: std.str
@@ -94,7 +94,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res.foo, "hello")
 
     def test_qb_computed_05(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.User.select(
@@ -115,7 +115,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res2.name_len, 15)
 
     def test_qb_computed_06(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.User.select(
@@ -144,7 +144,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res3.name, "A!")
 
     def test_qb_order_01(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.query(default.User.order_by(name=True))
         self.assertEqual(
@@ -153,7 +153,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_order_02(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.GameSession.select(
@@ -171,7 +171,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_order_03(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.GameSession.select(
@@ -188,7 +188,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_filter_01(self):
-        from models import default, std
+        from models.orm import default, std
 
         res = self.client.query(
             default.User.filter(lambda u: std.like(u.name, "%e%")).order_by(
@@ -215,7 +215,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(list(res), list(res2))
 
     def test_qb_filter_02(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.UserGroup.select("*", users=True).filter(name="red")
@@ -229,7 +229,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_filter_03(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.UserGroup.select(
@@ -245,7 +245,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_filter_04(self):
-        from models import default, std
+        from models.orm import default, std
 
         res = self.client.get(
             default.UserGroup.select(
@@ -263,7 +263,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_filter_05(self):
-        from models import default, std
+        from models.orm import default, std
 
         # Test filter by ad-hoc computed
         res = self.client.get(
@@ -277,7 +277,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_filter_06(self):
-        from models import default, std
+        from models.orm import default, std
 
         # Test filter by compex expression
         res = self.client.get(
@@ -295,7 +295,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res.count, 2)
 
     def test_qb_filter_07(self):
-        from models import default
+        from models.orm import default
 
         # Test filter with nested property expression
         res = self.client.query(
@@ -310,7 +310,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(res[1].body, "I'm Alice")
 
     def test_qb_filter_08(self):
-        from models import default, std
+        from models.orm import default, std
 
         # Test filter with nested property expression
         res = self.client.query(
@@ -325,7 +325,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_filter_09(self):
-        from models import default, std
+        from models.orm import default, std
 
         # Find GameSession with same players as the green group
         green = default.UserGroup.filter(name="green")
@@ -345,7 +345,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_filter_10(self):
-        from models import default, std
+        from models.orm import default, std
 
         # Find GameSession with same *number* of players as the green group
         green = default.UserGroup.filter(name="green")
@@ -361,7 +361,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_link_property_01(self):
-        from models import default
+        from models.orm import default
 
         # Test fetching GameSession with players multi-link
         res = self.client.get(
@@ -379,7 +379,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_link_property_02(self):
-        from models import default
+        from models.orm import default
 
         # Test filtering players based on link property
         res = self.client.get(
@@ -394,7 +394,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual([u.name for u in res.players], ["Billie"])
 
     def test_qb_multiprop_01(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.query(
             default.KitchenSink.select(
@@ -411,7 +411,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_multiprop_02(self):
-        from models import default
+        from models.orm import default
 
         # FIXME: This straight up hangs
         raise Exception("This filter will hang")
@@ -426,7 +426,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_multiprop_03(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.KitchenSink.select(
@@ -440,7 +440,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_multiprop_04(self):
-        from models import default
+        from models.orm import default
 
         res = self.client.get(
             default.KitchenSink.select(
@@ -454,7 +454,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_multiprop_05(self):
-        from models import default, std
+        from models.orm import default, std
 
         res = self.client.get(
             default.KitchenSink.select(
@@ -469,7 +469,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(set(res.p_multi_str), {"brown", "jumps"})
 
     def test_qb_limit_offset_01(self):
-        from models import default, std
+        from models.orm import default, std
 
         res = self.client.get(
             default.User.select(name=True)
@@ -486,7 +486,7 @@ class TestQueryBuilder(tb.ModelTestCase):
         )
 
     def test_qb_boolean_operator_error_01(self):
-        from models import default
+        from models.orm import default
 
         # Test that using 'and' operator raises TypeError
         with self.assertRaisesRegex(TypeError, "use std.and_"):
@@ -535,7 +535,7 @@ class TestQueryBuilder(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_enum_01(self):
-        from models import default
+        from models.orm import default
 
         e = self.client.get(default.EnumTest.filter(color=default.Color.Red))
 
@@ -553,7 +553,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
     ISOLATED_TEST_BRANCHES = True
 
     def test_qb_update_01(self):
-        from models import default
+        from models.orm import default
 
         self.client.query(
             default.User.filter(name="Alice").update(
@@ -567,7 +567,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
         self.assertEqual(res.nickname, "singer")
 
     def test_qb_update_02(self):
-        from models import default, std
+        from models.orm import default, std
 
         self.client.query(
             default.UserGroup.filter(name="blue").update(
@@ -585,7 +585,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_update_03(self):
-        from models import default, std
+        from models.orm import default, std
 
         # Combine update and select of the updated object
         res = self.client.get(
@@ -602,7 +602,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_update_04(self):
-        from models import default, std
+        from models.orm import default, std
 
         self.client.query(
             default.UserGroup.filter(name="blue").update(
@@ -651,7 +651,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
         self.assertEqual({u.name for u in res2.users}, {"Zoe", "Alice"})
 
     def test_qb_delete_01(self):
-        from models import default
+        from models.orm import default
 
         before = self.client.query(
             default.Post.select(body=True).order_by(body=True)
@@ -672,7 +672,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
         )
 
     def test_qb_delete_02(self):
-        from models import default
+        from models.orm import default
 
         before = self.client.query(
             default.Post.select(body=True).order_by(body=True)
@@ -695,7 +695,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
         )
 
     def test_qb_delete_03(self):
-        from models import default
+        from models.orm import default
 
         # Delete posts by Alice and fetch the deleted stuff
         res = self.client.query(
@@ -712,7 +712,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_enum_edit_01(self):
-        from models import default
+        from models.orm import default
 
         e = self.client.get(
             default.EnumTest.filter(
@@ -727,7 +727,7 @@ class TestQueryBuilderModify(tb.ModelTestCase):
 
     @tb.xfail
     def test_qb_enum_edit_02(self):
-        from models import default
+        from models.orm import default
 
         e = self.client.get(
             default.EnumTest.filter(


### PR DESCRIPTION
Pulls out updates to tools/gen_models from #858.