### PR TITLE
Fixes to sync()

### DIFF
--- a/gel/_internal/_qbmodel/_abstract/_descriptors.py
+++ b/gel/_internal/_qbmodel/_abstract/_descriptors.py
@@ -750,10 +750,12 @@ def reconcile_link(
     existing_objects: dict[uuid.UUID, _MT_co | Iterable[_MT_co]],
     new_objects: dict[uuid.UUID, _MT_co],
 ) -> _MT_co:
-    if existing is not None:
-        return existing
-
     obj_id: uuid.UUID = ll_getattr(refetched, "id")
+
+    if existing is not None:
+        existing_id = ll_getattr(existing, "id")
+        if existing_id == obj_id:
+            return existing
 
     if (link_to := existing_objects.get(obj_id)) is not None:
         if isinstance(link_to, AbstractGelModel):
@@ -771,15 +773,18 @@ def reconcile_proxy_link(
     existing_objects: dict[uuid.UUID, _MT_co | Iterable[_MT_co]],
     new_objects: dict[uuid.UUID, _MT_co],
 ) -> AbstractGelProxyModel[_MT_co, _LM_co]:
-    if existing is not None:
-        # `refetched` will have newly refetched __linkprops__,
-        # so copy them
-        existing.__gel_replace_linkprops__(
-            copy_or_ref_lprops(refetched.__linkprops__)
-        )
-        return existing
-
     obj_id: uuid.UUID = ll_getattr(refetched.without_linkprops(), "id")
+
+    if existing is not None:
+        existing_id: uuid.UUID = ll_getattr(existing.without_linkprops(), "id")
+
+        if existing_id == obj_id:
+            # `refetched` will have newly refetched __linkprops__,
+            # so copy them
+            existing.__gel_replace_linkprops__(
+                copy_or_ref_lprops(refetched.__linkprops__)
+            )
+            return existing
 
     if (_link_to := existing_objects.get(obj_id)) is not None:
         if isinstance(_link_to, AbstractGelModel):

--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -653,29 +653,31 @@ class AsyncIOClient(
             async with tx:
                 executor = make_executor()
 
-                with executor:
-                    for batches in executor:
-                        for batch in batches:
-                            await tx.send_query(batch.query, batch.args)
-                        batch_ids = await tx.wait()
-                        for ids, batch in zip(batch_ids, batches, strict=True):
-                            batch.feed_db_data(ids)
+                for batches in executor:
+                    for batch in batches:
+                        await tx.send_query(batch.query, batch.args)
+                    batch_ids = await tx.wait()
+                    for ids, batch in zip(batch_ids, batches, strict=True):
+                        batch.record_inserted_data(ids)
 
-                    if refetch:
-                        ref_queries = executor.get_refetch_queries()
-                        for ref in ref_queries:
-                            await tx.send_query(
-                                ref.query,
-                                spec=ref.args.spec,
-                                new=ref.args.new,
-                                existing=ref.args.existing,
-                            )
+                if refetch:
+                    ref_queries = executor.get_refetch_queries()
+                    for ref in ref_queries:
+                        await tx.send_query(
+                            ref.query,
+                            spec=ref.args.spec,
+                            new=ref.args.new,
+                            existing=ref.args.existing,
+                        )
 
-                        refetch_data = await tx.wait()
-                        for ref_data, ref in zip(
-                            refetch_data, ref_queries, strict=True
-                        ):
-                            ref.feed_db_data(ref_data)
+                    refetch_data = await tx.wait()
+
+                    for ref_data, ref in zip(
+                        refetch_data, ref_queries, strict=True
+                    ):
+                        ref.record_refetched_data(ref_data)
+
+        executor.commit()
 
     async def save(
         self,

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -3862,9 +3862,6 @@ class TestModelGenerator(tb.ModelTestCase):
         # Was alice reloaded? That's the object used in tlt.user
         self.assertEqual(alice.nickname, "magical unicorn")
 
-    @tb.xfail
-    # error from saving tsl2
-    # more than one row returned by a subquery used as an expression
     def test_modelgen_save_reload_links_04(self):
         from models.orm import default
 
@@ -3885,7 +3882,7 @@ class TestModelGenerator(tb.ModelTestCase):
 
         self.client.sync(tsl)
 
-        # Computed links should not be set after save
+        # Computed links should not be set -- we never fetched them
         with self.assertRaisesRegex(
             AttributeError, "'comp_req_wprop_friend' is not set"
         ):
@@ -3971,26 +3968,11 @@ class TestModelGenerator(tb.ModelTestCase):
         self.assertEqual(tsl2.opt_friend.name, "Billie")
         self.assertEqual(tsl2.opt_wprop_friend.name, "Billie")
 
-        # But computed links should no longer be set after the save
-        with self.assertRaisesRegex(
-            AttributeError, "'comp_req_wprop_friend' is not set"
-        ):
-            assert tsl2.comp_req_wprop_friend is not None  # access field
-
-        with self.assertRaisesRegex(
-            AttributeError, "'comp_req_friend' is not set"
-        ):
-            assert tsl2.comp_req_friend is not None  # access field
-
-        with self.assertRaisesRegex(
-            AttributeError, "'comp_opt_friend' is not set"
-        ):
-            assert tsl2.comp_opt_friend is not None  # access field
-
-        with self.assertRaisesRegex(
-            AttributeError, "'comp_opt_wprop_friend' is not set"
-        ):
-            assert tsl2.comp_opt_wprop_friend is not None  # access field
+        # Computed links should be up to date after the sync
+        self.assertEqual(tsl2.comp_req_wprop_friend.name, "Billie")
+        self.assertEqual(tsl2.comp_req_friend.name, "Billie")
+        self.assertEqual(tsl2.comp_opt_friend.name, "Billie")
+        self.assertEqual(tsl2.comp_opt_wprop_friend.name, "Billie")
 
     def test_modelgen_save_reload_links_05(self):
         from models.orm import default


### PR DESCRIPTION
* Save/sync executor attempted to commit changes to pydantic objects even when there was an exception inside its context manager

* Sync was writing changes to pydantic objects while the transaction was still open

* Fix sync() to update single links properly and handle the case when a linked object is replaced with a different one

* Drop BlockingClient.__save_debug__ method, it's quite outdated and must be broken