### PR TITLE
Refetch computed for newly inserted objects

### DIFF
--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -643,18 +643,12 @@ def _add_refetch_shape(
                 ref_shape.fields[field_name] = ptr_info
 
     else:
-        # New objects only need computeds refetched
-        for field_name in obj.__pydantic_computed_fields__:
-            if field_name in ref_shape.fields:
+        # New objects only need computed properties refetched
+        for ptr_name, ptr_info in tp_pointers.items():
+            if not ptr_info.computed or ptr_info.kind != PointerKind.Property:
                 continue
 
-            try:
-                ptr_info = tp_pointers[field_name]
-            except KeyError:
-                # ad-hoc computed
-                pass
-            else:
-                ref_shape.fields[field_name] = ptr_info
+            ref_shape.fields[ptr_name] = ptr_info
 
 
 def push_refetch_new(

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -1719,8 +1719,12 @@ class SaveExecutor:
 
                 # Update new objects with refetched data
                 for prop in get_pointers(type(obj)):
-                    if prop.name not in new_obj.__dict__:
+                    if (
                         # prop not refetched
+                        prop.name not in new_obj.__dict__
+                        # TODO: Refetching links for new objects
+                        or prop.kind == PointerKind.Link
+                    ):
                         continue
 
                     obj.__dict__[prop.name] = new_obj.__dict__[prop.name]

--- a/tests/dbsetup/chemistry.gel
+++ b/tests/dbsetup/chemistry.gel
@@ -27,6 +27,9 @@ module default {
 
         # Computed single link
         compound := .<atoms[is Compound];
+
+        # Computed single prop
+        compound_name := .<atoms[is Compound].name;
     };
 
     type Compound extending Named {

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -90,7 +90,6 @@ class TestModelSync(tb.ModelTestCase):
         # Check that computed values are fetched
         self.assertEqual(ref_atom.weight, 1.008)
 
-    @tb.xfail
     def test_model_sync_new_obj_computed_03(self):
         # Computed from links to existing and new items
 
@@ -112,10 +111,9 @@ class TestModelSync(tb.ModelTestCase):
         self.assertEqual(new_atom.weight, 4.0026)
         self.assertEqual(new_atom.total_bond_count, 0)
         self.assertEqual(new_atom.total_bond_weight, 0)
-        self.assertEqual(reactor.total_weight, 4.0026)  # Failing
-        self.assertEqual(reactor.atom_weights, [4.0026])  # Failing
+        self.assertEqual(reactor.total_weight, 4.0026)
+        self.assertEqual(reactor.atom_weights, (4.0026,))
 
-    @tb.xfail
     def test_model_sync_new_obj_computed_04(self):
         # Computed from links to existing and new items
 
@@ -143,7 +141,7 @@ class TestModelSync(tb.ModelTestCase):
         h_2.bonds = [default.Atom.bonds.link(o_1, count=1)]
 
         hydrogen_atoms = [h_1, h_2]
-        oxygen_atoms = [h_1, h_2]
+        oxygen_atoms = [o_1]
 
         # Sync
         self.client.sync(*hydrogen_atoms, *oxygen_atoms)
@@ -153,11 +151,11 @@ class TestModelSync(tb.ModelTestCase):
             [atom.weight for atom in hydrogen_atoms],
             [1.008, 1.008],
         )
-        self.assertEqual(  # Failing
+        self.assertEqual(
             [atom.total_bond_count for atom in hydrogen_atoms],
             [1, 1],
         )
-        self.assertEqual(  # Failing
+        self.assertEqual(
             [atom.total_bond_weight for atom in hydrogen_atoms],
             [15.999, 15.999],
         )
@@ -166,21 +164,21 @@ class TestModelSync(tb.ModelTestCase):
             [atom.weight for atom in oxygen_atoms],
             [15.999],
         )
-        self.assertEqual(  # Failing
+        self.assertEqual(
             [atom.total_bond_count for atom in oxygen_atoms],
             [2],
         )
-        self.assertEqual(  # Failing
+        self.assertEqual(
             [atom.total_bond_weight for atom in oxygen_atoms],
             [1.008 * 2],
         )
 
-        self.assertEqual(  # Failing
+        self.assertEqual(
             reactor.total_weight,
             1.008 * 2 + 15.999,
         )
-        self.assertEqual(  # Failing
-            list(sorted(reactor.atom_weights)),
+        self.assertEqual(
+            tuple(sorted(reactor.atom_weights)),
             (1.008, 1.008, 15.999),
         )
 

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -667,7 +667,7 @@ class TestModelSyncComputedSingleProp(tb.ModelTestCase):
         }
 
         type FromStableExpr {
-            val := count(FromStableExpr);
+            val := count(detached FromStableExpr);
         };
 
         global SomeGlobal: int64;
@@ -885,8 +885,10 @@ class TestModelSyncComputedSingleProp(tb.ModelTestCase):
         from models.TestModelSyncComputedSingleProp import default
 
         target = default.Target(val=1)
-        original = default.FromSingleLink()
-        self.client.sync(original, target)
+        self.client.save(target)
+
+        original = default.FromSingleLink(target=target)
+        self.client.sync(original)
 
         target.val = 9
         self.client.sync(original, target)
@@ -1886,7 +1888,7 @@ class TestModelSyncComputedMultiProp(tb.ModelTestCase):
         }
 
         type FromStableExpr {
-            val := array_unpack(array_fill(9, count(FromStableExpr)));
+            val := array_unpack(array_fill(9, count(detached FromStableExpr)));
         };
 
         global SomeGlobal: int64;
@@ -2104,8 +2106,10 @@ class TestModelSyncComputedMultiProp(tb.ModelTestCase):
         from models.TestModelSyncComputedMultiProp import default
 
         target = default.Target(val=1)
-        original = default.FromSingleLink()
-        self.client.sync(original, target)
+        self.client.save(target)
+
+        original = default.FromSingleLink(target=target)
+        self.client.sync(original)
 
         target.val = 9
         self.client.sync(original, target)


### PR DESCRIPTION
Given a schema
```
type A {
   total_val := sum(.<a[is B].val);
};
type B {
    a: A;
    val: int64;
};
```

If a user does:
```
a = default.A()
b = default.B(a=a, val=7)

client.sync(a, b)
```

The order of inserts will be `a`, then `b` and so the value of `a.total_val` fetched during the insert will be 0.

This PR adds a refetch query for the computed properties of newly inserted objects.

Tests are based on https://github.com/geldata/gel-python/issues/848