### PR TITLE
fastapi auth: reuse verifier to continue the flow

### DIFF
--- a/gel/_internal/_auth/_builtin_ui.py
+++ b/gel/_internal/_auth/_builtin_ui.py
@@ -34,13 +34,22 @@ C = TypeVar("C", bound=httpx.Client | httpx.AsyncClient)
 
 class BaseBuiltinUI(base.BaseClient[C]):
     def start_sign_in(
-        self, *, error: Optional[str] = None
+        self,
+        *,
+        error: Optional[str] = None,
+        verifier: Optional[str] = None,
     ) -> BuiltinUIResponse:
         logger.info("starting sign-in flow")
-        pkce = self._generate_pkce()
+
+        if verifier is None:
+            pkce = self._generate_pkce()
+        else:
+            pkce = self._pkce_from_verifier(verifier)
+
         redirect_url = self._client.base_url.join("ui/signin").copy_set_param(
             "challenge", pkce.challenge
         )
+
         if error is not None:
             redirect_url = redirect_url.copy_set_param("error", error)
 

--- a/gel/_internal/_integration/_fastapi/_auth/_builtin_ui.py
+++ b/gel/_internal/_integration/_fastapi/_auth/_builtin_ui.py
@@ -121,8 +121,13 @@ class BuiltinUI(Installable):
                 content={"error": "not implemented", "method": method},
             )
 
-    def _redirect_error(self, message: str) -> fastapi.Response:
-        result = self._core.start_sign_in(error=message)
+    def _redirect_error(
+        self,
+        message: str,
+        *,
+        verifier: Optional[str] = None,
+    ) -> fastapi.Response:
+        result = self._core.start_sign_in(error=message, verifier=verifier)
         response = self.callback_default_response_class.value(
             url=str(result.redirect_url),
             status_code=self.callback_default_status_code.value,
@@ -171,7 +176,10 @@ class BuiltinUI(Installable):
                         request, verification_email_sent_at
                     )
                 else:
-                    return self._redirect_error("Email verification required")
+                    return self._redirect_error(
+                        "Email verification required",
+                        verifier=verifier,
+                    )
 
             else:
                 token_data = await self._core.get_token(


### PR DESCRIPTION
If email confirmation is required to complete the sign-up , the verifier will be overwritten after being redirected to the sign-in page, resulting in an error when exchanging tokens when following the link from the email