### PR TITLE
Make model generation more (ideally fully?) deterministic

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -1023,7 +1023,8 @@ class BaseGeneratedModule:
                 )
                 self.write(f"return {objtype_mod}.ObjectType(")
                 with self.indented():
-                    self.write(f"id={uuid_}(int={objtype.uuid.int}),")
+                    self.write(f"# Dummy id, for stability/portability")
+                    self.write(f"id={uuid_}(int=0),")
                     self.write(f"name={objtype.name!r},")
                     self.write(f"builtin={objtype.builtin!r},")
                     self.write(f"internal={objtype.internal!r},")
@@ -1277,7 +1278,11 @@ class BaseGeneratedModule:
         t: reflection.NamedTupleType,
     ) -> str:
         names = [elem.name.capitalize() for elem in t.tuple_elements]
-        digest = base64.b64encode(t.uuid.bytes[:4], altchars=b"__").decode()
+        # Base64ing the name is pretty horrific but it avoids needing
+        # to escape it into Python safely.
+        digest = base64.b64encode(
+            t.name.encode("utf-8"), altchars=b"__"
+        ).decode()
         return "".join(names) + "_Tuple_" + digest.rstrip("=")
 
     def _resolve_rel_import(
@@ -3026,6 +3031,7 @@ class GeneratedSchemaModule(BaseGeneratedModule):
         ]
         | None = None,
     ) -> None:
+        callables = sorted(callables, key=lambda c: c.ident)
         partitions = self._partition_nominal_overloads(callables)
         for overloads in partitions.values():
             self._write_nominal_overloads(
@@ -3079,7 +3085,10 @@ class GeneratedSchemaModule(BaseGeneratedModule):
             overloads
         )
         num_generated_total = 0
-        for overlapping in partitions.values():
+        # Sort for determinism.
+        for _, overlapping in sorted(
+            partitions.items(), key=lambda kv: kv[0].sort_key()
+        ):
             generated = self._write_potentially_overlapping_overloads(
                 overlapping,
                 style=style,
@@ -3147,14 +3156,19 @@ class GeneratedSchemaModule(BaseGeneratedModule):
             reflection.CallableParamKey, set[_Callable_T]
         ] = defaultdict(set)
 
-        # Sort overloads by generality from least generic to most generic
+        # Sort overloads by generality from least generic to most
+        # generic, which is needed for typing correctness, and then by
+        # their edgeql signature, to ensure determisim.
         generality_key = functools.cmp_to_key(
             functools.partial(
                 reflection.compare_callable_generality,
                 schema=self._types,
             )
         )
-        overloads = sorted(overloads, key=generality_key)
+        overloads = sorted(
+            overloads,
+            key=lambda o: (generality_key(o), o.edgeql_signature),
+        )
 
         for overload in overloads:
             overload_signatures[overload] = {}

--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -16,11 +16,11 @@ from typing import (
 )
 from typing_extensions import TypeAliasType
 
-import base64
 import contextlib
 import dataclasses
 import enum
 import functools
+import hashlib
 import itertools
 import json
 import graphlib
@@ -1278,12 +1278,10 @@ class BaseGeneratedModule:
         t: reflection.NamedTupleType,
     ) -> str:
         names = [elem.name.capitalize() for elem in t.tuple_elements]
-        # Base64ing the name is pretty horrific but it avoids needing
+        # SHAing the name is pretty horrific but it avoids needing
         # to escape it into Python safely.
-        digest = base64.b64encode(
-            t.name.encode("utf-8"), altchars=b"__"
-        ).decode()
-        return "".join(names) + "_Tuple_" + digest.rstrip("=")
+        digest = hashlib.sha256(t.name.encode("utf-8")).hexdigest()[:10]
+        return "".join(names) + "_Tuple_" + digest
 
     def _resolve_rel_import(
         self,

--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -3158,7 +3158,17 @@ class GeneratedSchemaModule(BaseGeneratedModule):
 
         # Sort overloads by generality from least generic to most
         # generic, which is needed for typing correctness, and then by
-        # their edgeql signature, to ensure determisim.
+        # their edgeql signature, to ensure determinism.
+
+        # TEMPORARY (I HOPE) HACK: We sort the edgeql signatures first
+        # in reverse order, because it keeps certain standard library
+        # operations from breaking. (contains on a range in particular)
+        overloads = sorted(
+            overloads,
+            key=lambda o: o.edgeql_signature,
+            reverse=True,
+        )
+
         generality_key = functools.cmp_to_key(
             functools.partial(
                 reflection.compare_callable_generality,
@@ -3167,7 +3177,9 @@ class GeneratedSchemaModule(BaseGeneratedModule):
         )
         overloads = sorted(
             overloads,
-            key=lambda o: (generality_key(o), o.edgeql_signature),
+            key=generality_key,
+            # SEE ABOVE: This is what we actually want.
+            # key=lambda o: (generality_key(o), o.edgeql_signature),
         )
 
         for overload in overloads:

--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -1023,7 +1023,7 @@ class BaseGeneratedModule:
                 )
                 self.write(f"return {objtype_mod}.ObjectType(")
                 with self.indented():
-                    self.write(f"# Dummy id, for stability/portability")
+                    self.write("# Dummy id, for stability/portability")
                     self.write(f"id={uuid_}(int=0),")
                     self.write(f"name={objtype.name!r},")
                     self.write(f"builtin={objtype.builtin!r},")
@@ -3179,7 +3179,7 @@ class GeneratedSchemaModule(BaseGeneratedModule):
             overloads,
             key=generality_key,
             # SEE ABOVE: This is what we actually want.
-            # key=lambda o: (generality_key(o), o.edgeql_signature),
+            # key=lambda o: (generality_key(o), o.edgeql_signature),  # noqa: ERA001, E501
         )
 
         for overload in overloads:

--- a/gel/_internal/_reflection/_callables.py
+++ b/gel/_internal/_reflection/_callables.py
@@ -213,6 +213,21 @@ class CallableSignature(NamedTuple):
     kwargs: frozenset[str]
     kwargs_with_defaults: frozenset[str]
 
+    def sort_key(self) -> tuple[object, ...]:
+        """Produce something that is safe to sort on
+
+        Sets < is set inclusion, which is not something you can sort
+        an array with!
+        """
+        return (
+            self.name,
+            self.num_pos,
+            self.num_pos_with_defaults,
+            self.has_variadic,
+            sorted(self.kwargs),
+            sorted(self.kwargs_with_defaults),
+        )
+
     def contains(self, other: CallableSignature) -> bool:
         """Determine if this signature contains the other signature.
 

--- a/gel/_internal/_reflection/_query.py
+++ b/gel/_internal/_reflection/_query.py
@@ -259,8 +259,8 @@ SELECT Type {
                 EXISTS .default
                 OR ("std::sequence" IN .target[IS ScalarType].ancestors.name)
             ),
-        } FILTER .name != 'source' AND .name != 'target'
-    } FILTER any(@is_owned),
+        } FILTER .name != 'source' AND .name != 'target' ORDER BY .name
+    } FILTER any(@is_owned) ORDER BY .name,
     exclusives := assert_distinct((
         [IS schema::ObjectType].constraints
         UNION

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -259,6 +259,8 @@ class ObjectType(InheritingType):
     union_of: tuple[TypeRef, ...]
     intersection_of: tuple[TypeRef, ...]
     compound_type: bool
+    # N.B: We store Pointers sorted by name, from the
+    # introspection query
     pointers: tuple[Pointer, ...]
 
     def get_pointer(self, name: str) -> Pointer:
@@ -729,6 +731,8 @@ class Pointer(SchemaObject):
     is_computed: bool
     is_readonly: bool
     has_default: bool
+    # N.B: We store Pointers sorted by name, from the
+    # introspection query
     pointers: tuple[Pointer, ...] | None = None
 
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -6255,7 +6255,6 @@ class TestModelGenerator(tb.ModelTestCase):
     def test_modelgen_operators_range_contains(self):
         """Test string containment and pattern matching operators"""
         from models.orm import default, std
-        from gel import Range
 
         res = self.client.query(
             default.RangeTest.filter(

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -6251,6 +6251,23 @@ class TestModelGenerator(tb.ModelTestCase):
         for user in users_with_char:
             self.assertTrue(search_char in user.name.lower())
 
+    @tb.xfail
+    def test_modelgen_operators_range_contains(self):
+        """Test string containment and pattern matching operators"""
+        from models.orm import default, std
+        from gel import Range
+
+        res = self.client.query(
+            default.RangeTest.filter(
+                lambda u: std.contains(u.int_range, u.int_range))
+        )
+        # This one doesn't typecheck
+        # res = self.client.query(
+        #     default.RangeTest.filter(
+        #         lambda u: std.contains(u.int_range, Range(30, 31)))
+        # )
+        self.assertEqual(len(res), 1)
+
     def test_modelgen_operators_numeric(self):
         """Test numeric operators with edge cases and mixed precision"""
         from models.orm import default, std

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -1546,7 +1546,7 @@ class TestModelGenerator(tb.ModelTestCase):
         )
         self.assertEqual(
             g.model_dump_json(context={"gel_allow_unsaved": True}),
-            '{"num":1,"public":true,"players":[]}',
+            '{"num":1,"players":[],"public":true}',
         )
 
     def test_modelgen_pydantic_apis_20(self):
@@ -6475,13 +6475,15 @@ class TestEmptyAiModelGenerator(tb.ModelTestCase):
         from models.empty_ai.ext import ai  # noqa: F401
 
 
-class TestModelGeneratorReproducibility(tb.ModelTestCase):
+class TestModelGeneratorReproducibility(tb.SyncQueryTestCase):
+    DEFAULT_MODULE = "default"
     SCHEMA = os.path.join(os.path.dirname(__file__), "dbsetup", "orm.gel")
 
     def test_modelgen_reproducibility(self):
         conn_env = {}
         for k, v in self.get_connect_args().items():
             conn_env[f"EDGEDB_{k.upper()}"] = str(v)
+        conn_env['EDGEDB_DATABASE'] = self.get_database_name()
 
         env = os.environ | conn_env
 
@@ -6502,6 +6504,12 @@ class TestModelGeneratorReproducibility(tb.ModelTestCase):
                     if prev_models.exists():
                         shutil.rmtree(prev_models)
                     os.rename(td / "models", prev_models)
+
+                if i == 1:
+                    # Drop the database and recreate it, to test that
+                    # we are reproducible across that.
+                    self.tearDownClass()
+                    self.setUpClass()
 
                 env["PYTHONHASHSEED"] = str(hashseed)
                 subprocess.run(


### PR DESCRIPTION
The generation was not very deterministic, and the reproducibility test
wasn't catching it.  Dropping and recreating the database between cycles
exposed a lot of issues (including still embedding ids).

 * Don't embed id in schema object values. Put a dummy in instead.
  (Will this be a problem?)
* Sort groups of potentially overlapping functions by their
  CallableSignatures
* Inside overlapping groups, sort by edgeql_signature in addition
  to their "generality_key"
* Don't use base64 of ids to generate Tuple names. Instead use
  a base64 of name. This produces kind of horrific names; at some
  point we should try to safely produce something based on the
  actual name.