### PR TITLE
Add tests for syncing single and multi props

### DIFF
--- a/tests/nested_collections.py
+++ b/tests/nested_collections.py
@@ -1,0 +1,219 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+import abc
+import typing
+
+from gel._internal._tracked_list import AbstractTrackedList
+
+# Useful functions for working with nested collections
+
+
+class NonStrSequence(abc.ABC):
+    @classmethod
+    def __subclasshook__(cls, C):
+        # not possible to do with AnyStr
+        if issubclass(C, (str, bytes)):
+            return NotImplemented
+        else:
+            return issubclass(C, typing.Sequence)
+
+    @abc.abstractmethod
+    def dummy(self):
+        # ruff complains if we don't have an abstract method
+        pass
+
+
+def get_value(
+    collection: typing.Sequence[typing.Any],
+    indexes: list[int],
+) -> typing.Any:
+    if len(indexes) > 1:
+        return get_value(collection[indexes[0]], indexes[1:])
+    elif len(indexes) == 1:
+        return collection[indexes[0]]
+    else:
+        raise RuntimeError
+
+
+def set_prop_value(
+    collection: AbstractTrackedList[typing.Any] | tuple[typing.Any],
+    indexes: list[int],
+    val: typing.Any,
+) -> tuple[typing.Any] | None:
+    # Modify, and also return, a prop list with the value at an index set to
+    # a new value.
+
+    assert indexes
+
+    # If the collection is a tuple, we return the modified tuple and update
+    # the owner.
+    if isinstance(collection, tuple):
+        if len(indexes) == 1:
+            return (
+                collection[: indexes[0]]
+                + (val,)
+                + collection[indexes[0] + 1 :]
+            )
+
+        else:
+            inner_tuple_changed = set_prop_value(
+                collection[indexes[0]],
+                indexes[1:],
+                val,
+            )
+            if inner_tuple_changed:
+                return typing.cast(
+                    tuple,
+                    collection[: indexes[0]]
+                    + (inner_tuple_changed,)
+                    + collection[indexes[0] + 1 :],
+                )
+            else:
+                return None
+
+    elif isinstance(collection, (AbstractTrackedList, list)):
+        if len(indexes) == 1:
+            collection[indexes[0]] = val
+        else:
+            inner_tuple_changed = set_prop_value(
+                collection[indexes[0]],
+                indexes[1:],
+                val,
+            )
+            if inner_tuple_changed:
+                collection[indexes[0]] = inner_tuple_changed
+        return None
+
+    else:
+        raise RuntimeError
+
+
+def replace_value(
+    collection: list[typing.Any] | tuple[typing.Any, ...],
+    indexes: list[int],
+    val: typing.Any,
+) -> list[typing.Any] | tuple[typing.Any, ...]:
+    assert indexes
+
+    if isinstance(collection, list):
+        return (
+            collection[: indexes[0]]
+            + (
+                [
+                    typing.cast(
+                        list,
+                        replace_value(
+                            collection[indexes[0]],
+                            indexes[1:],
+                            val,
+                        ),
+                    )
+                ]
+                if len(indexes) > 1
+                else [val]
+            )
+            + collection[indexes[0] + 1 :]
+        )
+
+    elif isinstance(collection, tuple):
+        return (
+            collection[: indexes[0]]
+            + (
+                (
+                    typing.cast(
+                        tuple,
+                        replace_value(
+                            collection[indexes[0]],
+                            indexes[1:],
+                            val,
+                        ),
+                    ),
+                )
+                if len(indexes) > 1
+                else (val,)
+            )
+            + collection[indexes[0] + 1 :]
+        )
+
+    else:
+        raise RuntimeError
+
+
+def first_indexes(
+    collection: typing.Sequence[typing.Any],
+) -> list[int]:
+    if not collection:
+        return []
+    if isinstance(collection[0], NonStrSequence):
+        return [0] + first_indexes(collection[0])
+    else:
+        return [0]
+
+
+def increment_indexes(
+    collection: typing.Sequence[typing.Any],
+    indexes: list[int],
+) -> list[int]:
+    # Iterate through all indexes, with children taking priority.
+    #
+    # eg. Iterating over ((0, 1), (2, 3)) will produce:
+    # - [0, 0]
+    # - [0, 1]
+    # - [0]
+    # - [1, 0]
+    # - [1, 1]
+    # - [1]
+    assert indexes
+
+    if len(indexes) > 1:
+        return indexes[:1] + increment_indexes(
+            collection[indexes[0]], indexes[1:]
+        )
+
+    elif len(indexes) == 1:
+        next_index = indexes[0] + 1
+        if next_index >= len(collection):
+            return []
+
+        return [next_index] + (
+            first_indexes(collection[next_index])
+            if isinstance(collection[next_index], NonStrSequence)
+            else []
+        )
+
+    else:
+        raise RuntimeError
+
+
+def different_values_same_shape(val: typing.Any) -> typing.Any:
+    if isinstance(val, list):
+        return [different_values_same_shape(val) for val in val]
+
+    elif isinstance(val, tuple):
+        return tuple(different_values_same_shape(val) for val in val)
+
+    elif isinstance(val, str):
+        return val + "?"
+
+    elif isinstance(val, int):
+        return val + 100
+
+    else:
+        raise RuntimeError

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -6554,3 +6554,36 @@ class TestModelGeneratorReproducibility(tb.SyncQueryTestCase):
                             "Generated model output is nondeterministic:\n\n"
                             + "\n".join(diff)
                         )
+
+
+@tb.typecheck
+class TestModelGenDirect(tb.ModelTestCase):
+    SCHEMA = """
+        type Foo {
+            required x: int64;
+            squared := .x * .x;
+        };
+    """
+
+    SETUP = """
+        create type Bar {
+            create required property x: int64;
+            create property squared := .x * .x;
+        };
+    """
+
+    def test_model_gen_direct_01(self):
+        from models.TestModelGenDirect import default
+
+        foo = default.Foo(x=11)
+        self.client.sync(foo)
+
+        self.assertEqual(foo.squared, 121)
+
+    def test_model_gen_direct_02(self):
+        from models.TestModelGenDirect import default
+
+        bar = default.Bar(x=12)
+        self.client.sync(bar)
+
+        self.assertEqual(bar.squared, 144)

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -253,6 +253,9 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
             self.assertEqual(with_val.val, val)
             self.assertIsNone(without_val.val)
 
+            # cleanup
+            self.client.query(model_type.delete())
+
         _testcase(default.A, None)
         _testcase(default.A, 1)
         _testcase(default.B, [1, 2, 3])
@@ -271,7 +274,6 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
 
     def test_model_sync_single_prop_02(self):
         # Updating existing objects with single props
-        # Set prop to new value
 
         from models.TestModelSyncSingleProp import default
 
@@ -310,6 +312,10 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
             self.assertEqual(mirror_2.val, initial_val)
             # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
 
+            # cleanup
+            self.client.query(model_type.delete())
+
+        # Change to a new value
         _testcase(default.A, 1, 2)
         _testcase(default.B, [1], [2])
         _testcase(default.C, ("a", 1), ("b", 2))
@@ -319,56 +325,47 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
         _testcase(default.H, [("a", [1])], [("b", [2])])
         _testcase(default.I, ("a", [("a", 1)]), ("b", [("b", 2)]))
 
+        # Change to the same value
+        _testcase(default.A, 1, 1)
+        _testcase(default.B, [1], [1])
+        _testcase(default.C, ("a", 1), ("a", 1))
+        _testcase(default.E, [("a", 1)], [("a", 1)])
+        _testcase(default.F, ("a", [1]), ("a", [1]))
+        _testcase(default.G, ("a", ("a", 1)), ("a", ("a", 1)))
+        _testcase(default.H, [("a", [1])], [("a", [1])])
+        _testcase(default.I, ("a", [("a", 1)]), ("a", [("a", 1)]))
+
+        # Change from None to value
+        _testcase(default.A, None, 1)
+        _testcase(default.B, None, [1])
+        _testcase(default.C, None, ("a", 1))
+        _testcase(default.E, None, [("a", 1)])
+        _testcase(default.F, None, ("a", [1]))
+        _testcase(default.G, None, ("a", ("a", 1)))
+        _testcase(default.H, None, [("a", [1])])
+        _testcase(default.I, None, ("a", [("a", 1)]))
+
+        # Change from value to None
+        _testcase(default.A, 1, None)
+        _testcase(default.B, [1], None)
+        _testcase(default.C, ("a", 1), None)
+        _testcase(default.E, [("a", 1)], None)
+        _testcase(default.F, ("a", [1]), None)
+        _testcase(default.G, ("a", ("a", 1)), None)
+        _testcase(default.H, [("a", [1])], None)
+        _testcase(default.I, ("a", [("a", 1)]), None)
+
+        # Change from None to None
+        _testcase(default.A, None, None)
+        _testcase(default.B, None, None)
+        _testcase(default.C, None, None)
+        _testcase(default.E, None, None)
+        _testcase(default.F, None, None)
+        _testcase(default.G, None, None)
+        _testcase(default.H, None, None)
+        _testcase(default.I, None, None)
+
     def test_model_sync_single_prop_03(self):
-        # Updating existing objects with single props
-        # Set prop to None
-
-        from models.TestModelSyncSingleProp import default
-
-        def _testcase(
-            model_type: typing.Type[GelModel],
-            initial_val: typing.Any,
-        ) -> None:
-            original = model_type(val=initial_val)
-            self.client.save(original)
-
-            mirror_1 = self.client.query_required_single(
-                model_type.select(val=True).limit(1)
-            )
-            mirror_2 = self.client.query_required_single(
-                model_type.select(val=True).limit(1)
-            )
-            mirror_3 = self.client.query_required_single(
-                model_type.select(val=False).limit(1)
-            )
-
-            self.assertEqual(original.val, initial_val)
-            self.assertEqual(mirror_1.val, initial_val)
-            self.assertEqual(mirror_2.val, initial_val)
-            self.assertFalse(hasattr(mirror_3, "val"))
-
-            # change a value
-            original.val = None
-
-            # sync some of the objects
-            self.client.sync(original, mirror_1, mirror_3)
-
-            # only synced objects with value set get update
-            self.assertIsNone(original.val)
-            self.assertIsNone(mirror_1.val)
-            self.assertEqual(mirror_2.val, initial_val)
-            # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
-
-        _testcase(default.A, 1)
-        _testcase(default.B, [1])
-        _testcase(default.C, ("a", 1))
-        _testcase(default.E, [("a", 1)])
-        _testcase(default.F, ("a", [1]))
-        _testcase(default.G, ("a", ("a", 1)))
-        _testcase(default.H, [("a", [1])])
-        _testcase(default.I, ("a", [("a", 1)]))
-
-    def test_model_sync_single_prop_04(self):
         # Reconciling different changes to single props
 
         from models.TestModelSyncSingleProp import default
@@ -412,6 +409,9 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
             self.assertEqual(mirror_2.val, changed_val_2)
             # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
 
+            # cleanup
+            self.client.query(model_type.delete())
+
         _testcase(default.A, 1, 2, 3, 4)
         _testcase(default.B, [1], [2], [3], [4])
         _testcase(default.C, ("a", 1), ("b", 2), ("c", 3), ("d", 4))
@@ -440,7 +440,7 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
         )
 
     @tb.xfail
-    def test_model_sync_single_prop_05(self):
+    def test_model_sync_single_prop_04(self):
         # Changing elements of collection single props
         # Checks deeply nested collections as well
 
@@ -507,6 +507,9 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
                     expected_val, visiting_indexes
                 )
 
+            # cleanup
+            self.client.query(model_type.delete())
+
         _testcase(default.B, [1, 2, 3])
         _testcase(default.C, ("x", 1))
         _testcase(default.E, [("x", 1), ("y", 2), ("z", 3)])
@@ -522,7 +525,7 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
         )  # Fail
 
     @tb.xfail
-    def test_model_sync_single_prop_06(self):
+    def test_model_sync_single_prop_05(self):
         # Existing object without prop should not have it fetched
 
         from models.TestModelSyncSingleProp import default
@@ -579,6 +582,9 @@ class TestModelSyncMultiProp(tb.ModelTestCase):
 
             self.assertEqual(with_val.val, val)
             self.assertEqual(without_val.val, [])
+
+            # cleanup
+            self.client.query(model_type.delete())
 
         _testcase(default.A, [1, 2, 3])
         _testcase(default.B, [[1], [2, 2], [3, 3, 3]])
@@ -837,6 +843,9 @@ class TestModelSyncMultiProp(tb.ModelTestCase):
             self.assertEqual(mirror_1.val, [])
             self.assertEqual(mirror_2.val, initial_val)
             self.assertEqual(mirror_3.val, [])  # Fail
+
+            # cleanup
+            self.client.query(model_type.delete())
 
         _testcase(default.A, [1, 2, 3])
         _testcase(default.B, [[1], [2, 2], [3, 3, 3]])

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -328,7 +328,6 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
         def _testcase(
             model_type: typing.Type[GelModel],
             initial_val: typing.Any,
-            changed_val: typing.Any,
         ) -> None:
             original = model_type(val=initial_val)
             self.client.save(original)
@@ -360,14 +359,14 @@ class TestModelSyncSingleProp(tb.ModelTestCase):
             self.assertEqual(mirror_2.val, initial_val)
             # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
 
-        _testcase(default.A, 1, 2)
-        _testcase(default.B, [1], [2])
-        _testcase(default.C, ("a", 1), ("b", 2))
-        _testcase(default.E, [("a", 1)], [("b", 2)])
-        _testcase(default.F, ("a", [1]), ("b", [2]))
-        _testcase(default.G, ("a", ("a", 1)), ("b", ("b", 2)))
-        _testcase(default.H, [("a", [1])], [("b", [2])])
-        _testcase(default.I, ("a", [("a", 1)]), ("b", [("b", 2)]))
+        _testcase(default.A, 1)
+        _testcase(default.B, [1])
+        _testcase(default.C, ("a", 1))
+        _testcase(default.E, [("a", 1)])
+        _testcase(default.F, ("a", [1]))
+        _testcase(default.G, ("a", ("a", 1)))
+        _testcase(default.H, [("a", [1])])
+        _testcase(default.I, ("a", [("a", 1)]))
 
     def test_model_sync_single_prop_04(self):
         # Reconciling different changes to single props

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -40,7 +40,7 @@ from gel import _testbase as tb
 from gel._internal import _tracked_list
 from gel._internal._qbmodel._pydantic._models import GelModel
 
-from . import nested_collections
+from tests import nested_collections
 
 
 _T = typing.TypeVar("_T")

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -30,12 +30,25 @@
 #    Don't forget to re-run if you are messing with codegen
 #    implementation or testing different versions of Gel.
 
+from __future__ import annotations
+import typing
+
+import copy
 import os
 
 from gel import _testbase as tb
+from gel._internal import _tracked_list
+from gel._internal._qbmodel._pydantic._models import GelModel
+
+from . import nested_collections
+
+
+_T = typing.TypeVar("_T")
 
 
 class TestModelSync(tb.ModelTestCase):
+    ISOLATED_TEST_BRANCHES = True
+
     SCHEMA = os.path.join(
         os.path.dirname(__file__), "dbsetup", "chemistry.gel"
     )
@@ -169,3 +182,691 @@ class TestModelSync(tb.ModelTestCase):
             list(sorted(reactor.atom_weights)),
             (1.008, 1.008, 15.999),
         )
+
+
+class TestModelSyncBasic(tb.ModelTestCase):
+    ISOLATED_TEST_BRANCHES = True
+
+    SCHEMA = """
+        type O;
+    """
+
+    def test_model_sync_basic_01(self):
+        # Sync applies ids to new objects
+
+        from models.TestModelSyncBasic import default
+
+        synced = default.O()
+        unsynced = default.O()
+
+        self.client.sync(synced)
+
+        self.assertTrue(hasattr(synced, "id"))
+        self.assertFalse(hasattr(unsynced, "id"))
+
+
+class TestModelSyncSingleProp(tb.ModelTestCase):
+    ISOLATED_TEST_BRANCHES = True
+
+    SCHEMA = """
+        type A {
+            val: int64;
+        };
+        type B {
+            val: array<int64>;
+        };
+        type C {
+            val: tuple<str, int64>;
+        };
+        # save D for array<array<...>>
+        type E {
+            val: array<tuple<str, int64>>;
+        };
+        type F {
+            val: tuple<str, array<int64>>;
+        };
+        type G {
+            val: tuple<str, tuple<str, int64>>;
+        };
+        type H {
+            val: array<tuple<str, array<int64>>>;
+        };
+        type I {
+            val: tuple<str, array<tuple<str, int64>>>;
+        };
+    """
+
+    def test_model_sync_single_prop_01(self):
+        # Insert new object with single prop
+
+        from models.TestModelSyncSingleProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            val: typing.Any,
+        ) -> None:
+            with_val = model_type(val=val)
+            without_val = model_type()
+
+            self.client.sync(with_val, without_val)
+
+            self.assertEqual(with_val.val, val)
+            self.assertIsNone(without_val.val)
+
+        _testcase(default.A, None)
+        _testcase(default.A, 1)
+        _testcase(default.B, [1, 2, 3])
+        _testcase(default.C, ("x", 1))
+        _testcase(default.E, [("x", 1), ("y", 2), ("z", 3)])
+        _testcase(default.F, ("x", [1, 2, 3]))
+        _testcase(default.G, ("x", ("x", 1)))
+        _testcase(
+            default.H,
+            [("x", [1, 2, 3]), ("y", [4, 5, 6]), ("z", [7, 8, 9])],
+        )
+        _testcase(
+            default.I,
+            ("w", [("x", 1), ("y", 2), ("z", 3)]),
+        )
+
+    def test_model_sync_single_prop_02(self):
+        # Updating existing objects with single props
+        # Set prop to new value
+
+        from models.TestModelSyncSingleProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            initial_val: typing.Any,
+            changed_val: typing.Any,
+        ) -> None:
+            original = model_type(val=initial_val)
+            self.client.save(original)
+
+            mirror_1 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_2 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_3 = self.client.query_required_single(
+                model_type.select(val=False).limit(1)
+            )
+
+            self.assertEqual(original.val, initial_val)
+            self.assertEqual(mirror_1.val, initial_val)
+            self.assertEqual(mirror_2.val, initial_val)
+            self.assertFalse(hasattr(mirror_3, "val"))
+
+            # change a value
+            original.val = changed_val
+
+            # sync some of the objects
+            self.client.sync(original, mirror_1, mirror_3)
+
+            # only synced objects with value set get update
+            self.assertEqual(original.val, changed_val)
+            self.assertEqual(mirror_1.val, changed_val)
+            self.assertEqual(mirror_2.val, initial_val)
+            # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
+
+        _testcase(default.A, 1, 2)
+        _testcase(default.B, [1], [2])
+        _testcase(default.C, ("a", 1), ("b", 2))
+        _testcase(default.E, [("a", 1)], [("b", 2)])
+        _testcase(default.F, ("a", [1]), ("b", [2]))
+        _testcase(default.G, ("a", ("a", 1)), ("b", ("b", 2)))
+        _testcase(default.H, [("a", [1])], [("b", [2])])
+        _testcase(default.I, ("a", [("a", 1)]), ("b", [("b", 2)]))
+
+    def test_model_sync_single_prop_03(self):
+        # Updating existing objects with single props
+        # Set prop to None
+
+        from models.TestModelSyncSingleProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            initial_val: typing.Any,
+            changed_val: typing.Any,
+        ) -> None:
+            original = model_type(val=initial_val)
+            self.client.save(original)
+
+            mirror_1 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_2 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_3 = self.client.query_required_single(
+                model_type.select(val=False).limit(1)
+            )
+
+            self.assertEqual(original.val, initial_val)
+            self.assertEqual(mirror_1.val, initial_val)
+            self.assertEqual(mirror_2.val, initial_val)
+            self.assertFalse(hasattr(mirror_3, "val"))
+
+            # change a value
+            original.val = None
+
+            # sync some of the objects
+            self.client.sync(original, mirror_1, mirror_3)
+
+            # only synced objects with value set get update
+            self.assertIsNone(original.val)
+            self.assertIsNone(mirror_1.val)
+            self.assertEqual(mirror_2.val, initial_val)
+            # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
+
+        _testcase(default.A, 1, 2)
+        _testcase(default.B, [1], [2])
+        _testcase(default.C, ("a", 1), ("b", 2))
+        _testcase(default.E, [("a", 1)], [("b", 2)])
+        _testcase(default.F, ("a", [1]), ("b", [2]))
+        _testcase(default.G, ("a", ("a", 1)), ("b", ("b", 2)))
+        _testcase(default.H, [("a", [1])], [("b", [2])])
+        _testcase(default.I, ("a", [("a", 1)]), ("b", [("b", 2)]))
+
+    def test_model_sync_single_prop_04(self):
+        # Reconciling different changes to single props
+
+        from models.TestModelSyncSingleProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            initial_val: typing.Any,
+            changed_val_0: typing.Any,
+            changed_val_1: typing.Any,
+            changed_val_2: typing.Any,
+        ) -> None:
+            original = model_type(val=initial_val)
+            self.client.save(original)
+
+            mirror_1 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_2 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_3 = self.client.query_required_single(
+                model_type.select(val=False).limit(1)
+            )
+
+            self.assertEqual(original.val, initial_val)
+            self.assertEqual(mirror_1.val, initial_val)
+            self.assertEqual(mirror_2.val, initial_val)
+            self.assertFalse(hasattr(mirror_3, "val"))
+
+            # change a value
+            original.val = changed_val_0
+            mirror_1.val = changed_val_1
+            mirror_2.val = changed_val_2
+
+            # sync some of the objects
+            self.client.sync(original, mirror_1, mirror_3)
+
+            # only synced objects are updated
+            self.assertEqual(original.val, changed_val_0)
+            self.assertEqual(mirror_1.val, changed_val_0)
+            self.assertEqual(mirror_2.val, changed_val_2)
+            # self.assertFalse(hasattr(mirror_3, 'val'))  # Fail
+
+        _testcase(default.A, 1, 2, 3, 4)
+        _testcase(default.B, [1], [2], [3], [4])
+        _testcase(default.C, ("a", 1), ("b", 2), ("c", 3), ("d", 4))
+        _testcase(default.E, [("a", 1)], [("b", 2)], [("c", 3)], [("d", 4)])
+        _testcase(default.F, ("a", [1]), ("b", [2]), ("c", [3]), ("d", [4]))
+        _testcase(
+            default.G,
+            ("a", ("a", 1)),
+            ("b", ("b", 2)),
+            ("c", ("c", 3)),
+            ("d", ("d", 4)),
+        )
+        _testcase(
+            default.H,
+            [("a", [1])],
+            [("b", [2])],
+            [("c", [3])],
+            [("d", [4])],
+        )
+        _testcase(
+            default.I,
+            ("a", [("a", 1)]),
+            ("b", [("b", 2)]),
+            ("c", [("c", 3)]),
+            ("d", [("d", 4)]),
+        )
+
+    @tb.xfail
+    def test_model_sync_single_prop_05(self):
+        # Changing elements of collection single props
+        # Checks deeply nested collections as well
+
+        from models.TestModelSyncSingleProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            initial_val: typing.Any,
+        ) -> None:
+            original = model_type(val=initial_val)
+            self.client.save(original)
+
+            mirror_1 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+
+            self.assertEqual(original.val, initial_val)
+            self.assertEqual(mirror_1.val, initial_val)
+
+            expected_val = copy.deepcopy(initial_val)
+
+            # Iterate through all indexes of the collection
+            # eg. [(1, 2), (3, 4)] will go through the indexes:
+            # - [0, 0]
+            # - [0, 1]
+            # - [0]
+            # - [1, 0]
+            # - [1, 1]
+            # - [1]
+            visiting_indexes = nested_collections.first_indexes(expected_val)
+            while visiting_indexes:
+                # Create a new value with the same "shape" as it was initially
+                changed_val = nested_collections.different_values_same_shape(
+                    nested_collections.get_value(
+                        initial_val,
+                        visiting_indexes,
+                    )
+                )
+
+                # Modify the prop
+                maybe_modified_prop = nested_collections.set_prop_value(
+                    original.val,
+                    visiting_indexes,
+                    changed_val,
+                )
+                if maybe_modified_prop:
+                    # modifying tuples requires setting the updated value
+                    original.val = maybe_modified_prop
+
+                # Modify the expected val
+                expected_val = nested_collections.replace_value(
+                    expected_val,
+                    visiting_indexes,
+                    changed_val,
+                )
+
+                # sync and check objects are updated
+                self.client.sync(original, mirror_1)
+                self.assertEqual(original.val, expected_val)
+                self.assertEqual(mirror_1.val, expected_val)
+
+                # visit next index
+                visiting_indexes = nested_collections.increment_indexes(
+                    expected_val, visiting_indexes
+                )
+
+        _testcase(default.B, [1, 2, 3])
+        _testcase(default.C, ("x", 1))
+        _testcase(default.E, [("x", 1), ("y", 2), ("z", 3)])
+        _testcase(default.F, ("x", [1, 2, 3]))  # Fail
+        _testcase(default.G, ("x", ("x", 1)))
+        _testcase(
+            default.H,
+            [("x", [1, 2, 3]), ("y", [4, 5, 6]), ("z", [7, 8, 9])],
+        )  # Fail
+        _testcase(
+            default.I,
+            ("w", [("x", 1), ("y", 2), ("z", 3)]),
+        )  # Fail
+
+    @tb.xfail
+    def test_model_sync_single_prop_06(self):
+        # Existing object without prop should not have it fetched
+
+        from models.TestModelSyncSingleProp import default
+
+        original = default.A(val=1)
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+        original.val = 2
+        self.client.save(original)
+        self.client.sync(mirror_1)
+        self.assertFalse(hasattr(mirror_1, "val"))
+
+        # Sync alongside another object with the prop set
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        original.val = 3
+        self.client.save(original)
+        self.client.sync(mirror_1, mirror_2)
+        self.assertFalse(hasattr(mirror_1, "val"))  # Fail
+
+
+class TestModelSyncMultiProp(tb.ModelTestCase):
+    ISOLATED_TEST_BRANCHES = True
+
+    SCHEMA = """
+        type A {
+            multi val: int64;
+        };
+        type B {
+            multi val: array<int64>;
+        };
+        type C {
+            multi val: tuple<str, int64>;
+        };
+    """
+
+    def test_model_sync_multi_prop_01(self):
+        # Insert new object with multi prop
+
+        from models.TestModelSyncMultiProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            val: typing.Any,
+        ) -> None:
+            with_val = model_type(val=val)
+            without_val = model_type()
+
+            self.client.sync(with_val, without_val)
+
+            self.assertEqual(with_val.val, val)
+            self.assertEqual(without_val.val, [])
+
+        _testcase(default.A, [1, 2, 3])
+        _testcase(default.B, [[1], [2, 2], [3, 3, 3]])
+        _testcase(default.C, [("a", 1), ("b", 2), ("c", 3)])
+
+    @tb.xfail
+    def test_model_sync_multi_prop_02(self):
+        # Updating existing objects with multi props
+        # Set prop to new value
+
+        from models.TestModelSyncMultiProp import default
+
+        initial_val = [1, 2, 3]
+        changed_val = [4, 5, 6]
+
+        original = default.A(val=initial_val)
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_3 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+
+        self.assertEqual(original.val, initial_val)
+        self.assertEqual(mirror_1.val, initial_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        self.assertEqual(mirror_3.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_3.val._items, [])
+
+        # change a value
+        original.val = changed_val
+
+        # sync some of the objects
+        self.client.sync(original, mirror_1, mirror_3)
+
+        # only synced objects with value set get update
+        self.assertEqual(original.val, changed_val)
+        self.assertEqual(mirror_1.val, changed_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        # self.assertEqual(mirror_3.val, [])
+
+    def test_model_sync_multi_prop_03(self):
+        # Updating existing objects with multi props
+        # Tracked list insert
+
+        from models.TestModelSyncMultiProp import default
+
+        initial_val = [1, 2, 3]
+        insert_pos = 2
+        insert_val = 9
+
+        original = default.A(val=initial_val)
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_3 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+
+        self.assertEqual(original.val, initial_val)
+        self.assertEqual(mirror_1.val, initial_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        self.assertEqual(mirror_3.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_3.val._items, [])
+
+        # change a value
+        original.val.insert(insert_pos, insert_val)
+
+        expected_val = initial_val.copy()
+        expected_val.append(insert_val)
+
+        # sync some of the objects
+        self.client.sync(original, mirror_1, mirror_3)
+
+        # only synced objects with value set get update
+        self.assertEqual(list(sorted(original.val)), expected_val)
+        self.assertEqual(list(sorted(mirror_1.val)), expected_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        # self.assertEqual(mirror_3.val, [])  # Fail
+
+    def test_model_sync_multi_prop_04(self):
+        # Updating existing objects with multi props
+        # Tracked list extend
+
+        from models.TestModelSyncMultiProp import default
+
+        initial_val = [1, 2, 3]
+        extend_vals = [4, 5, 6]
+
+        original = default.A(val=initial_val)
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_3 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+
+        self.assertEqual(original.val, initial_val)
+        self.assertEqual(mirror_1.val, initial_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        self.assertEqual(mirror_3.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_3.val._items, [])
+
+        # change a value
+        original.val.extend(extend_vals)
+
+        expected_val = initial_val.copy()
+        expected_val.extend(extend_vals)
+
+        # sync some of the objects
+        self.client.sync(original, mirror_1, mirror_3)
+
+        # only synced objects with value set get update
+        self.assertEqual(list(sorted(original.val)), expected_val)
+        self.assertEqual(list(sorted(mirror_1.val)), expected_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        # self.assertEqual(mirror_3.val, [])  # Fail
+
+    def test_model_sync_multi_prop_05(self):
+        # Updating existing objects with multi props
+        # Tracked list append
+
+        from models.TestModelSyncMultiProp import default
+
+        initial_val = [1, 2, 3]
+        append_val = 4
+
+        original = default.A(val=initial_val)
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_3 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+
+        self.assertEqual(original.val, initial_val)
+        self.assertEqual(mirror_1.val, initial_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        self.assertEqual(mirror_3.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_3.val._items, [])
+
+        # change a value
+        original.val.append(append_val)
+
+        expected_val = initial_val.copy()
+        expected_val.append(append_val)
+
+        # sync some of the objects
+        self.client.sync(original, mirror_1, mirror_3)
+
+        # only synced objects with value set get update
+        self.assertEqual(list(sorted(original.val)), expected_val)
+        self.assertEqual(list(sorted(mirror_1.val)), expected_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        # self.assertEqual(mirror_3.val, [])  # Fail
+
+    def test_model_sync_multi_prop_06(self):
+        # Updating existing objects with multi props
+        # Tracked list pop
+
+        from models.TestModelSyncMultiProp import default
+
+        initial_val = [1, 2, 3]
+
+        original = default.A(val=initial_val)
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        mirror_3 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+
+        self.assertEqual(original.val, initial_val)
+        self.assertEqual(mirror_1.val, initial_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        self.assertEqual(mirror_3.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_3.val._items, [])
+
+        # change a value
+        original.val.pop()
+
+        expected_val = initial_val.copy()
+        expected_val.pop()
+
+        # sync some of the objects
+        self.client.sync(original, mirror_1, mirror_3)
+
+        # only synced objects with value set get update
+        self.assertEqual(list(sorted(original.val)), expected_val)
+        self.assertEqual(list(sorted(mirror_1.val)), expected_val)
+        self.assertEqual(mirror_2.val, initial_val)
+        # self.assertEqual(mirror_3.val, [])  # Fail
+
+    def test_model_sync_multi_prop_07(self):
+        # Updating existing objects with single props
+        # Clear prop
+
+        from models.TestModelSyncMultiProp import default
+
+        def _testcase(
+            model_type: typing.Type[GelModel],
+            initial_val: typing.Any,
+        ) -> None:
+            original = model_type(val=initial_val)
+            self.client.save(original)
+
+            mirror_1 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_2 = self.client.query_required_single(
+                model_type.select(val=True).limit(1)
+            )
+            mirror_3 = self.client.query_required_single(
+                model_type.select(val=False).limit(1)
+            )
+
+            self.assertEqual(original.val, initial_val)
+            self.assertEqual(mirror_1.val, initial_val)
+            self.assertEqual(mirror_2.val, initial_val)
+            self.assertEqual(mirror_3.val._mode, _tracked_list.Mode.Write)
+            self.assertEqual(mirror_3.val._items, [])
+
+            # change a value
+            original.val.clear()
+
+            # sync some of the objects
+            self.client.sync(original, mirror_1, mirror_3)
+
+            # only synced objects with value set get update
+            self.assertEqual(original.val, [])
+            self.assertEqual(mirror_1.val, [])
+            self.assertEqual(mirror_2.val, initial_val)
+            self.assertEqual(mirror_3.val, [])  # Fail
+
+        _testcase(default.A, [1, 2, 3])
+        _testcase(default.B, [[1], [2, 2], [3, 3, 3]])
+        _testcase(default.C, [("a", 1), ("b", 2), ("c", 3)])
+
+    @tb.xfail
+    def test_model_sync_multi_prop_08(self):
+        # Existing object without prop should not have it fetched
+
+        from models.TestModelSyncMultiProp import default
+
+        original = default.A(val=[1])
+        self.client.save(original)
+
+        mirror_1 = self.client.query_required_single(
+            default.A.select(val=False).limit(1)
+        )
+        original.val = [2]
+        self.client.save(original)
+        self.client.sync(mirror_1)
+        self.assertEqual(mirror_1.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_1.val._items, [])
+
+        # Sync alongside another object with the prop set
+        mirror_2 = self.client.query_required_single(
+            default.A.select(val=True).limit(1)
+        )
+        original.val = [3]
+        self.client.save(original)
+        self.client.sync(mirror_1, mirror_2)
+        self.assertEqual(mirror_1.val._mode, _tracked_list.Mode.Write)
+        self.assertEqual(mirror_1.val._items, [])


### PR DESCRIPTION
related #848

Test failures:
- `test_model_sync_single_prop_05`: modifying the inner elements of a nested collection prop does not sync (eg. `tuple<array<int64>>`
- `test_model_sync_multi_prop_02`: assigning a new list to a multi-prop does not remove the previous values

Maybe not actual bugs
- `test_model_sync_single_prop_06` and `test_model_sync_multi_prop_08`: objects without a prop set will have it fetched if synced alongside objects with the prop set