### PR TITLE
Add tx._batch()

### DIFF
--- a/gel/asyncio_client.py
+++ b/gel/asyncio_client.py
@@ -600,7 +600,7 @@ class AsyncIOBatchRetry(transaction.BaseRetry):
 
     async def __anext__(self) -> AsyncIOBatchIteration:
         # Note: when changing this code consider also
-        # updating Batch.__next__.
+        # updating BatchRetry.__next__.
         if self._done:
             raise StopAsyncIteration
         if self._next_backoff:

--- a/gel/blocking_client.py
+++ b/gel/blocking_client.py
@@ -622,7 +622,7 @@ class Batch(transaction.BaseRetry):
 
     def __next__(self) -> BatchIteration:
         # Note: when changing this code consider also
-        # updating AsyncIOBatch.__anext__.
+        # updating AsyncIOBatchRetry.__anext__.
         if self._done:
             raise StopIteration
         if self._next_backoff:

--- a/gel/transaction.py
+++ b/gel/transaction.py
@@ -197,7 +197,8 @@ class BaseTransaction:
             and issubclass(extype, errors.EdgeDBError)
             and ex.has_tag(errors.SHOULD_RETRY)
         ):
-            return self.__retry._retry(ex)
+            rv = self.__retry._retry(ex)
+            return rv
 
     def _get_query_cache(self) -> abstract.QueryCache:
         return self._client._get_query_cache()
@@ -242,6 +243,16 @@ class BaseTransaction:
                 annotations=self._get_annotations(),
             )
         )
+
+    async def _batch_query(
+        self,
+        ops: list[
+            abstract.BaseQueryContext[typing.Any]
+            | abstract.ExecuteContext[typing.Any]
+        ],
+    ) -> list[typing.Any]:
+        await self._ensure_transaction()
+        return await self._connection.batch_query(ops)
 
 
 class BaseRetry:

--- a/gel/transaction.py
+++ b/gel/transaction.py
@@ -197,8 +197,7 @@ class BaseTransaction:
             and issubclass(extype, errors.EdgeDBError)
             and ex.has_tag(errors.SHOULD_RETRY)
         ):
-            rv = self.__retry._retry(ex)
-            return rv
+            return self.__retry._retry(ex)
 
     def _get_query_cache(self) -> abstract.QueryCache:
         return self._client._get_query_cache()


### PR DESCRIPTION
So that:

```python
async for client.transaction() as tx:
    async with tx:
        async with tx._batch() as batch:
            await batch.send_query(...)
```

Note, `client._batch()` disables idle transaction timeout, but `tx._batch()` won't.

- [x] Do the same on blocking tx