### PR TITLE
Have gen_models.py put py.typed in the installed site-packages directory

### DIFF
--- a/tools/gen_models.py
+++ b/tools/gen_models.py
@@ -142,6 +142,8 @@ def main() -> None:  # noqa: D401 – simple script entry-point
                     ],
                     cwd=tmpdir,
                 )
+                with open(Path(tmpdir) / "models" / "py.typed", "w") as f:
+                    pass
 
                 # 4. Install models into *site-packages*.
                 if (


### PR DESCRIPTION
This will get mypy to check it. pyright checks it anyway, it seems, which
I think violates a PEP? IDK.