### PR TITLE
Add a `for_in` operator

### DIFF
--- a/gel/__init__.py
+++ b/gel/__init__.py
@@ -51,6 +51,8 @@ from .options import State
 
 from .errors._base import EdgeDBError, EdgeDBMessage
 
+from . import qb
+
 __all__ = [
     "Array",
     "AsyncIOClient",
@@ -84,6 +86,7 @@ __all__ = [
     "create_client",
     "default_backoff",
     "expr",
+    "qb",
 ]
 
 

--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -1782,6 +1782,10 @@ class GeneratedSchemaModule(BaseGeneratedModule):
         self._scalar_generics: dict[str, str] = {}
 
     def process(self, mod: IntrospectedModule) -> None:
+        if str(self.canonical_modpath) == 'std':
+            self.write("# Re-export top-level query-builder functions")
+            self.write("from gel.qb import *")
+
         self.prepare_namespace(mod)
         self.write_generic_types(mod)
         self.write_scalar_types(mod["scalar_types"])

--- a/gel/_internal/_qb/_expressions.py
+++ b/gel/_internal/_qb/_expressions.py
@@ -723,7 +723,7 @@ class DeleteStmt(IteratorStmt):
 
 
 @dataclass(kw_only=True, frozen=True)
-class ForStmt(IteratorExpr):
+class ForStmt(IteratorExpr, Stmt):
     stmt: _edgeql.Token = _edgeql.Token.FOR
     iter_expr: Expr
     body: Expr
@@ -742,11 +742,18 @@ class ForStmt(IteratorExpr):
         return (self.iter_expr, self.body)
 
     def _edgeql(self, ctx: ScopeContext) -> str:
+        ctx.bind(self.var)
         return (
             f"{self.stmt} {edgeql(self.var, ctx=ctx)} IN "
             f"({edgeql(self.iter_expr, ctx=ctx)})\n"
             f"UNION ({edgeql(self.body, ctx=ctx)})"
         )
+
+    def _iteration_edgeql(self, ctx: ScopeContext) -> str:
+        raise AssertionError('...')
+
+    def _body_edgeql(self, ctx: ScopeContext) -> str:
+        raise AssertionError('...')
 
 
 class Splat(_strenum.StrEnum):

--- a/gel/_internal/ruff.toml
+++ b/gel/_internal/ruff.toml
@@ -24,7 +24,6 @@ extend-select = [
     "PIE", # flake8-pie
     "PL",  # pylint
     "PYI", # flake8-pyi
-    "Q",   # flake8-quotes
     "RUF", # ruff specific
     "S",   # flake8-bandit
     "SIM", # flake8-simplify

--- a/gel/models/ruff.toml
+++ b/gel/models/ruff.toml
@@ -24,7 +24,6 @@ extend-select = [
     "PIE", # flake8-pie
     "PL",  # pylint
     "PYI", # flake8-pyi
-    "Q",   # flake8-quotes
     "RUF", # ruff specific
     "S",   # flake8-bandit
     "SIM", # flake8-simplify

--- a/gel/qb.py
+++ b/gel/qb.py
@@ -17,7 +17,7 @@ _T = TypeVar("_T", bound=_abstract.GelType)
 _X = TypeVar("_X", bound=_abstract.GelType)
 
 
-def foreach(iter: type[_T], body: Callable[[type[_T]], type[_X]]) -> type[_X]:
+def for_in(iter: type[_T], body: Callable[[type[_T]], type[_X]]) -> type[_X]:
     """Evaluate the expression returned by *body* for each element in *iter*.
 
     This is the Pythonic representation of the EdgeQL FOR expression."""
@@ -37,5 +37,5 @@ def foreach(iter: type[_T], body: Callable[[type[_T]], type[_X]]) -> type[_X]:
 
 
 __all__ = (
-    "foreach",
+    "for_in",
 )

--- a/gel/qb.py
+++ b/gel/qb.py
@@ -36,6 +36,4 @@ def for_in(iter: type[_T], body: Callable[[type[_T]], type[_X]]) -> type[_X]:
     )
 
 
-__all__ = (
-    "for_in",
-)
+__all__ = ("for_in",)

--- a/gel/qb.py
+++ b/gel/qb.py
@@ -1,0 +1,42 @@
+# SPDX-PackageName: gel-python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright Gel Data Inc. and the contributors.
+
+
+"""Query building constructs"""
+
+from typing import TypeVar
+from collections.abc import Callable
+
+from gel._internal import _qb
+from gel._internal._qb import edgeql
+from gel._internal._qbmodel import _abstract
+
+
+_T = TypeVar("_T", bound=_abstract.GelType)
+_X = TypeVar("_X", bound=_abstract.GelType)
+
+
+def foreach(iter: type[_T], body: Callable[[type[_T]], type[_X]]) -> type[_X]:
+    """Evaluate the expression returned by *body* for each element in *iter*.
+
+    This is the Pythonic representation of the EdgeQL FOR expression."""
+
+    iter_expr = _qb.edgeql_qb_expr(iter)
+    scope = _qb.Scope()
+    var = _qb.Variable(name="x", type_=iter_expr.type, scope=scope)
+    type_ = body(_qb.AnnotatedVar(iter, var))  # type: ignore [arg-type]
+    return _qb.AnnotatedExpr(  # type: ignore [return-type]
+        type_,
+        _qb.ForStmt(
+            iter_expr=iter_expr,
+            body=_qb.edgeql_qb_expr(type_),
+            scope=scope,
+        ),
+    )
+
+
+__all__ = (
+    "edgeql",
+    "foreach",
+)

--- a/gel/qb.py
+++ b/gel/qb.py
@@ -24,19 +24,18 @@ def foreach(iter: type[_T], body: Callable[[type[_T]], type[_X]]) -> type[_X]:
 
     iter_expr = _qb.edgeql_qb_expr(iter)
     scope = _qb.Scope()
-    var = _qb.Variable(name="x", type_=iter_expr.type, scope=scope)
-    type_ = body(_qb.AnnotatedVar(iter, var))  # type: ignore [arg-type]
-    return _qb.AnnotatedExpr(  # type: ignore [return-type]
-        type_,
+    var = _qb.Variable(type_=iter_expr.type, scope=scope)
+    body_ = body(_qb.AnnotatedVar(iter.__gel_origin__, var))  # type: ignore [arg-type, attr-defined]
+    return _qb.AnnotatedExpr(  # type: ignore [return-value]
+        body_.__gel_origin__,  # type: ignore [attr-defined]
         _qb.ForStmt(
             iter_expr=iter_expr,
-            body=_qb.edgeql_qb_expr(type_),
+            body=_qb.edgeql_qb_expr(body_),
             scope=scope,
         ),
     )
 
 
 __all__ = (
-    "edgeql",
     "foreach",
 )

--- a/gel/qb.py
+++ b/gel/qb.py
@@ -9,7 +9,6 @@ from typing import TypeVar
 from collections.abc import Callable
 
 from gel._internal import _qb
-from gel._internal._qb import edgeql
 from gel._internal._qbmodel import _abstract
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ extend-ignore = [
     "E402", # module-import-not-at-top-of-file
     "E252", # missing-whitespace-around-parameter-equals
     "F541", # f-string-missing-placeholders
+    "Q000", # prefer double quotes
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ module = [
     "gel._internal._qbmodel.*",
     "gel._internal._qbmodel._abstract.*",
     "gel._internal._qbmodel._pydantic.*",
+    "gel.qb",
     "tests.test_dataclass_extras",
     "tests.test_dis_bool",
     "tests.test_is_overload",

--- a/tests/test_qb.py
+++ b/tests/test_qb.py
@@ -542,6 +542,29 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(e.color, default.Color.Red)
         self.assertEqual(e.name, "red")
 
+    def test_qb_for_01(self):
+        from models.orm import std
+
+        res = self.client.query(
+            std.for_in(
+                std.range_unpack(std.range(std.int64(1), std.int64(10))),
+                lambda x: x * 2,
+            )
+        )
+        self.assertEqual(set(res), {i * 2 for i in range(1, 10)})
+
+        res = self.client.query(
+            std.for_in(
+                std.range_unpack(std.range(std.int64(1), std.int64(3))),
+                lambda x: std.for_in(
+                    std.range_unpack(std.range(std.int64(1), std.int64(3))),
+                    lambda y: x * 10 + y,
+                )
+            )
+        )
+
+        self.assertEqual(set(res), {11, 12, 21, 22})
+
 
 class TestQueryBuilderModify(tb.ModelTestCase):
     """This test suite is for data manipulation using QB."""
@@ -739,26 +762,3 @@ class TestQueryBuilderModify(tb.ModelTestCase):
 
         self.assertEqual(e.color, default.Color.Violet)
         self.assertEqual(e.name, "red")
-
-    def test_qb_for_01(self):
-        from models.orm import std
-
-        res = self.client.query(
-            std.foreach(
-                std.range_unpack(std.range(std.int64(1), std.int64(10))),
-                lambda x: x * 2,
-            )
-        )
-        self.assertEqual(set(res), {i * 2 for i in range(1, 10)})
-
-        res = self.client.query(
-            std.foreach(
-                std.range_unpack(std.range(std.int64(1), std.int64(3))),
-                lambda x: std.foreach(
-                    std.range_unpack(std.range(std.int64(1), std.int64(3))),
-                    lambda y: x * 10 + y,
-                )
-            )
-        )
-
-        self.assertEqual(set(res), {11, 12, 21, 22})

--- a/tests/test_qb.py
+++ b/tests/test_qb.py
@@ -739,3 +739,26 @@ class TestQueryBuilderModify(tb.ModelTestCase):
 
         self.assertEqual(e.color, default.Color.Violet)
         self.assertEqual(e.name, "red")
+
+    def test_qb_for_01(self):
+        from models.orm import std
+
+        res = self.client.query(
+            std.foreach(
+                std.range_unpack(std.range(std.int64(1), std.int64(10))),
+                lambda x: x * 2,
+            )
+        )
+        self.assertEqual(set(res), {i * 2 for i in range(1, 10)})
+
+        res = self.client.query(
+            std.foreach(
+                std.range_unpack(std.range(std.int64(1), std.int64(3))),
+                lambda x: std.foreach(
+                    std.range_unpack(std.range(std.int64(1), std.int64(3))),
+                    lambda y: x * 10 + y,
+                )
+            )
+        )
+
+        self.assertEqual(set(res), {11, 12, 21, 22})


### PR DESCRIPTION
Following Elvis's original branch, I added it to a `gel.qb` module.
I also, on Elvis's suggestion, modified `std` to re-export everything
from `gel.qb`.

I renamed his `foreach` to `for_in` to better match EdgeQL.

Fixes #729.