### PR TITLE
Add caching and filtering to gen_models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs/_build
 /uv.lock
 .dir-locals.el
 .envrc
+.gen_models_cache

--- a/gel/_testbase.py
+++ b/gel/_testbase.py
@@ -643,6 +643,10 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
         return "\n\n".join(st for st in schema_texts)
 
     @classmethod
+    def is_schema_field(cls, field: str) -> bool:
+        return bool(re.match(r"^SCHEMA(?:_(\w+))?", field))
+
+    @classmethod
     def get_schema_text(cls, field: str) -> str | None:
         m = re.match(r"^SCHEMA(?:_(\w+))?", field)
         if not m:

--- a/gel/_testbase.py
+++ b/gel/_testbase.py
@@ -35,7 +35,6 @@ import pathlib
 import pickle
 import re
 import shutil
-import site
 import subprocess
 import sys
 import tempfile
@@ -63,12 +62,6 @@ from gel.orm.django.generator import ModelGenerator as DjangoModGen
 log = logging.getLogger(__name__)
 
 _unset = object()
-
-
-SITE_PACKAGES: typing.Final[pathlib.Path] = pathlib.Path(
-    site.getsitepackages()[0]
-)
-MODELS_DEST: typing.Final[pathlib.Path] = SITE_PACKAGES / "models"
 
 
 @contextlib.contextmanager
@@ -790,7 +783,7 @@ class BaseModelTestCase(DatabaseTestCase):
 
         cls.tmp_model_dir = tempfile.TemporaryDirectory(**td_kwargs)
 
-        model_from_file, model_name = cls._model_info()
+        _, model_name = cls._model_info()
 
         if cls.orm_debug:
             print(cls.tmp_model_dir.name)
@@ -829,15 +822,6 @@ class BaseModelTestCase(DatabaseTestCase):
                 ) from e
         finally:
             gen_client.terminate()
-
-        if not model_from_file:
-            # This is a direct schema, let's copy it to the site paths
-            site_model_dir = MODELS_DEST / model_name
-            if site_model_dir.exists():
-                shutil.rmtree(site_model_dir)
-            shutil.copytree(
-                model_output_dir, site_model_dir, dirs_exist_ok=True
-            )
 
         sys.path.insert(0, cls.tmp_model_dir.name)
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -6583,6 +6583,8 @@ class TestModelGenDirect(tb.ModelTestCase):
     def test_model_gen_direct_02(self):
         from models.TestModelGenDirect import default
 
+        # This still works because the actual test runs with a model generated
+        # after SETUP.
         bar = default.Bar(x=12)
         self.client.sync(bar)
 

--- a/tools/gen_models.py
+++ b/tools/gen_models.py
@@ -64,7 +64,8 @@ if not SCHEMAS_ROOT.exists():
 
 
 def _run(cmd: list[str] | tuple[str, ...], *, cwd: Path | None = None) -> None:
-    """Run *cmd* via :pyfunc:`subprocess.run` with *check=True* and TTY-friendly I/O."""
+    """Run *cmd* via :pyfunc:`subprocess.run` with *check=True* and
+    TTY-friendly I/O."""
     try:
         env = os.environ.copy()
         env['GEL_AUTO_BACKUP_MODE'] = 'disabled'
@@ -119,17 +120,19 @@ def main() -> None:  # noqa: D401 – simple script entry-point
                 shutil.copy2(schema_file, dbschema_dir / 'schema.gel')
 
                 _run(
-                    ["gel", "branch", "create", "--empty", schema_file.stem], cwd=tmpdir,
+                    ["gel", "branch", "create", "--empty", schema_file.stem],
+                    cwd=tmpdir,
                 )
 
                 _run(
-                    ["gel", "branch", "switch", schema_file.stem], cwd=tmpdir,
+                    ["gel", "branch", "switch", schema_file.stem],
+                    cwd=tmpdir,
                 )
-
 
                 # 3. Create & apply migration, then generate models.
                 _run(
-                    ["gel", "migration", "create", "--non-interactive"], cwd=tmpdir
+                    ["gel", "migration", "create", "--non-interactive"],
+                    cwd=tmpdir,
                 )
                 _run(["gel", "migrate"], cwd=tmpdir)
                 _run(
@@ -142,7 +145,7 @@ def main() -> None:  # noqa: D401 – simple script entry-point
                     ],
                     cwd=tmpdir,
                 )
-                with open(Path(tmpdir) / "models" / "py.typed", "w") as f:
+                with open(Path(tmpdir) / "models" / "py.typed", "w") as _:
                     pass
 
                 # 4. Install models into *site-packages*.
@@ -154,19 +157,20 @@ def main() -> None:  # noqa: D401 – simple script entry-point
                     )
                     raise SystemExit(1)
 
-                shutil.copytree(generated_models, MODELS_DEST, dirs_exist_ok=True)
-
-                print(
-                    f"✅  {schema_file.name} has been reflected"
+                shutil.copytree(
+                    generated_models, MODELS_DEST, dirs_exist_ok=True
                 )
 
+                print(f"✅  {schema_file.name} has been reflected")
 
             print(
-                f"✅  Models have been generated and installed into {MODELS_DEST}"
+                f"✅  Models have been generated and installed into "
+                f"{MODELS_DEST}"
             )
 
         finally:
-            # Always attempt cleanup of project & instance so we don't leak them
+            # Always attempt cleanup of project & instance so we don't leak
+            # them
             if instance_created:
                 try:
                     subprocess.run(


### PR DESCRIPTION
Adds the following flags to `tools/gen_models.py`:
- `-k` allows filtering for tests, similar to pytest
- `--cache` and `--no-cache` which allows skipping schemas which have not changed
    - If caching, the schemas are copied to `.gen_models_cache`