### PR TITLE
Fix syncing link with props set to None.

### DIFF
--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -758,7 +758,16 @@ def make_plan(
                     # `__gel_get_changed_fields__()`, se we process them
                     # separately).
 
-                    assert val is None or isinstance(val, GelModel)
+                    if val is None:
+                        sch = SingleLinkChange(
+                            name=prop.name,
+                            info=prop,
+                            target=None,
+                        )
+                        push_change(requireds, sched, sch)
+                        continue
+
+                    assert isinstance(val, GelModel)
                     assert not prop.cardinality.is_multi()
 
                     link_prop_variant = False


### PR DESCRIPTION
close #883

Given a schema:
```edgeql
type Target;
type SourceWithProp {
    target: Target {
        lprop: int64;
    };
};
```

the following code:
```py
with_none = default.SourceWithProp(target=None)
self.client.sync(with_none)
```

produced an `AssertionError:`
```cmd
File ".../edgedb-python/gel/_internal/_save.py", line 1105, in make_save_executor_constructor
) = make_plan(
    ^^^^^^^^^^
File ".../edgedb-python/gel/_internal/_save.py", line 737, in make_plan
assert isinstance(val, ProxyModel)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```