### PR TITLE
Fix ORDER BY in complex situations

### DIFF
--- a/gel/_internal/_qb/_expressions.py
+++ b/gel/_internal/_qb/_expressions.py
@@ -586,7 +586,7 @@ class InsertStmt(Stmt, TypedExpr):
 class IteratorStmt(ImplicitIteratorStmt):
     @property
     def precedence(self) -> _edgeql.Precedence:
-        token = _edgeql.Token.FOR if self.self_ref is not None else self.stmt
+        token = _edgeql.Token.WITH if self.self_ref is not None else self.stmt
         return _edgeql.PRECEDENCE[token]
 
     def _iteration_edgeql(self, ctx: ScopeContext) -> str:
@@ -605,9 +605,9 @@ class IteratorStmt(ImplicitIteratorStmt):
             if var is None:
                 raise AssertionError(f"{self.self_ref} in {self} is unbound")
             parts = [
-                _edgeql.Token.FOR,
+                _edgeql.Token.WITH,
                 var,
-                _edgeql.Token.IN,
+                _edgeql.Token.ASSIGN,
                 iterable,
                 self.stmt,
                 var,


### PR DESCRIPTION
Make IteratorStmt bind with WITH instead of FOR when
self_ref_must_bind.  This gives us a distinct name for the binding
but still relies on the Select or whatever to do the actual binding,
which makes ORDER BY work properly.

(Previously ORDER BY wouldn't work in these cases because it was
inside a FOR.)

Fixes #893.