### PR TITLE
Automatically wrap objects with the correct ProxyModel when passed to a link with props.

### DIFF
--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -372,7 +372,7 @@ class _AnyLink(Generic[_MT_co, _BMT_co]):
     def _validate(
         cls,
         value: Any,
-        generic_args: tuple[type[Any], type[Any]],
+        generic_args: tuple[type[_MT_co], type[_BMT_co]],
     ) -> _MT_co | None:
         mt, bmt = generic_args
 
@@ -390,7 +390,7 @@ class _AnyLink(Generic[_MT_co, _BMT_co]):
                 value = value._p__obj__
 
             if isinstance(value, mt):
-                return value  # type: ignore [no-any-return]
+                return value
         else:
             # link or optional link *with* props
             if isinstance(value, mt):
@@ -419,14 +419,16 @@ class _AnyLink(Generic[_MT_co, _BMT_co]):
                 )
 
         # defer to Pydantic
-        return mt.model_validate(value)  # type: ignore [no-any-return]
+        return mt.model_validate(value)
 
+
+class _AnyLinkWithProps(Generic[_PT_co, _BMT_co]):
     @classmethod
     def _validate_link_prop_target(
         cls,
-        value: Any,
-        generic_args: tuple[type[Any], type[Any]],
-    ) -> _MT_co | None:
+        value: GelModel,
+        generic_args: tuple[type[_PT_co], type[_BMT_co]],
+    ) -> GelModel | None:
         if isinstance(value, generic_args[1]) and not isinstance(
             value, generic_args[0]
         ):
@@ -469,7 +471,7 @@ class _OptionalLink(
     def _validate(
         cls,
         value: Any,
-        generic_args: tuple[type[Any], type[Any]],
+        generic_args: tuple[type[_MT_co], type[_BMT_co]],
     ) -> _MT_co | None:
         if value is None:
             return None
@@ -477,14 +479,15 @@ class _OptionalLink(
 
 
 class _OptionalLinkWithProps(
-    _OptionalLink[_MT_co, _BMT_co],
+    _OptionalLink[_PT_co, _BMT_co],
+    _AnyLinkWithProps[_PT_co, _BMT_co],
 ):
     @classmethod
     def _validate(
         cls,
         value: Any,
-        generic_args: tuple[type[Any], type[Any]],
-    ) -> _MT_co | None:
+        generic_args: tuple[type[_PT_co], type[_BMT_co]],
+    ) -> _PT_co | None:
         if value is None:
             return None
         value = cls._validate_link_prop_target(value, generic_args)
@@ -492,14 +495,15 @@ class _OptionalLinkWithProps(
 
 
 class _RequiredLinkWithProps(
-    _Link[_MT_co, _BMT_co],
+    _Link[_PT_co, _BMT_co],
+    _AnyLinkWithProps[_PT_co, _BMT_co],
 ):
     @classmethod
     def _validate(
         cls,
         value: Any,
-        generic_args: tuple[type[Any], type[Any]],
-    ) -> _MT_co | None:
+        generic_args: tuple[type[_PT_co], type[_BMT_co]],
+    ) -> _PT_co | None:
         value = cls._validate_link_prop_target(value, generic_args)
         return super()._validate(value, generic_args)
 

--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -511,14 +511,14 @@ class _RequiredLinkWithProps(
 RequiredLinkWithProps = TypeAliasType(
     "RequiredLinkWithProps",
     Annotated[
-        _RequiredLinkWithProps[_MT_co, _BMT_co],
+        _RequiredLinkWithProps[_PT_co, _BMT_co],
         PointerInfo(
             cardinality=_edgeql.Cardinality.One,
             kind=_edgeql.PointerKind.Link,
             has_props=True,
         ),
     ],
-    type_params=(_MT_co, _BMT_co),
+    type_params=(_PT_co, _BMT_co),
 )
 
 

--- a/tests/test_link_set_models.py
+++ b/tests/test_link_set_models.py
@@ -1637,7 +1637,7 @@ class TestLinkSetModels(tb.ModelTestCase):
         )
         self.assertEqual(
             {f: f.__linkprops__.opinion for f in harry.friends},
-            {hermione: "smart", ron: "reliable"},
+            {hermione: "smart", ron: None},
         )
 
     def test_link_set_model_modify_multi_link_with_props_update_02(self):
@@ -1765,7 +1765,7 @@ class TestLinkSetModels(tb.ModelTestCase):
         )
         self.assertEqual(
             {f: f.__linkprops__.opinion for f in harry.friends},
-            {hermione: "smart", ron: "reliable"},
+            {hermione: "smart", ron: None},
         )
 
     def test_link_set_model_modify_multi_link_with_props_op_iadd_02(self):

--- a/tests/test_link_with_props_set.py
+++ b/tests/test_link_with_props_set.py
@@ -3,6 +3,9 @@ import dataclasses
 from typing import Any
 import unittest
 
+from gel._internal import _qb
+from gel._internal._edgeql._schema import PointerKind, Cardinality
+from gel._internal._schemapath import SchemaPath
 from gel._internal._qbmodel import _abstract
 from gel._internal._qbmodel._abstract import (
     AbstractGelLinkModel,
@@ -45,6 +48,22 @@ class DummyIntList(LinkSet[DummyInt]):
 
 
 class DummyLinkModel(AbstractGelLinkModel):
+    class __gel_reflection__(AbstractGelLinkModel.__gel_reflection__):  # noqa: N801
+        pointers = {
+            "comment": _qb.GelPointerReflection(
+                name="comment",
+                type=SchemaPath("std", "str"),
+                typexpr="std::str",
+                kind=PointerKind.Property,
+                cardinality=Cardinality.AtMostOne,
+                computed=False,
+                readonly=False,
+                has_default=False,
+                properties=None,
+                mutable=True,
+            ),
+        }
+
     __gel_has_mutable_props__ = True
 
     def __init__(self, comment: str | None = None):

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -1102,13 +1102,17 @@ class TestModelGenerator(tb.ModelTestCase):
 
         t.opt_friend = u
 
-        # Assignment of a different ProxyModel is an error
-        with self.assertRaisesRegex(
-            ValueError, "satisfy Python type system restrictions"
-        ):
-            t.opt_wprop_friend = default.TestSingleLinks.req_wprop_friend.link(  # type: ignore [assignment]
-                u, strength=123
-            )
+        # Assignment of a different ProxyModel is ok, link props are dropped
+        t.opt_wprop_friend = default.TestSingleLinks.req_wprop_friend.link(  # type: ignore [assignment]
+            u, strength=123
+        )
+        assert t.opt_wprop_friend is not None
+        self.assertIsInstance(
+            t.opt_wprop_friend,
+            default.TestSingleLinks.__links__.opt_wprop_friend,
+        )
+        self.assertEqual(t.opt_wprop_friend, u)
+        self.assertIsNone(t.opt_wprop_friend.__linkprops__.strength)
 
         t.opt_wprop_friend = default.TestSingleLinks.opt_wprop_friend.link(
             u, strength=456
@@ -1814,12 +1818,15 @@ class TestModelGenerator(tb.ModelTestCase):
         self.assertEqual(t.req_wprop_friend.name, "bbb")
         self.assertEqual(t.req_wprop_friend.__linkprops__.strength, None)
 
-        with self.assertRaisesRegex(
-            ValueError,
-            r"(?s)is expected to satisfy Python type system.*"
-            r"models.orm.default.TestSingleLinks.opt_wprop_friend.link\(\)",
-        ):
-            t.opt_wprop_friend = u1  # type: ignore [assignment]
+        # directly assigning to unproxied target is ok
+        t.opt_wprop_friend = u1  # type: ignore [assignment]
+        assert t.opt_wprop_friend is not None
+        self.assertIsInstance(
+            t.opt_wprop_friend,
+            default.TestSingleLinks.__links__.opt_wprop_friend,
+        )
+        self.assertEqual(t.opt_wprop_friend, u1)
+        self.assertIsNone(t.opt_wprop_friend.__linkprops__.strength)
 
     def test_modelgen_save_01(self):
         from models.orm import default

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -2977,13 +2977,17 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         def _testcase(
             model_type: typing.Type[GelModel],
             initial_targets: typing.Collection[typing.Any],
+            expected_targets: typing.Collection[typing.Any] | None = None,
         ) -> None:
+            if expected_targets is None:
+                expected_targets = initial_targets
+
             with_targets = model_type(targets=initial_targets)
             without_targets = model_type()
 
             self.client.sync(with_targets, without_targets)
 
-            self._check_multilinks_equal(with_targets.targets, initial_targets)
+            self._check_multilinks_equal(with_targets.targets, expected_targets)
             self._check_multilinks_equal(without_targets.targets, [])
 
             # cleanup
@@ -2995,6 +2999,15 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
 
         # With linkprops
         _testcase(default.SourceWithProp, [])
+        _testcase(
+            default.SourceWithProp,
+            [target_a, target_b, target_c],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+        )
         _testcase(
             default.SourceWithProp,
             [
@@ -3025,12 +3038,16 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         model_type: typing.Type[GelModel],
         initial_targets: typing.Collection[typing.Any],
         changed_targets: typing.Collection[typing.Any],
+        expected_targets: typing.Collection[typing.Any] | None = None,
     ) -> None:
+        if expected_targets is None:
+            expected_targets = changed_targets
+
         self._base_testcase(
             model_type,
             initial_targets,
             self._get_assign_targets_func(changed_targets),
-            changed_targets,
+            expected_targets,
         )
 
     def test_model_sync_multi_link_02(self):
@@ -3091,6 +3108,16 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         self._testcase_assign(
             default.SourceWithProp,
             [],
+            [target_a, target_b, target_c],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+        )
+        self._testcase_assign(
+            default.SourceWithProp,
+            [],
             [
                 default.SourceWithProp.targets.link(target_a),
                 default.SourceWithProp.targets.link(target_b),
@@ -3115,6 +3142,20 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_c),
             ],
             [],
+        )
+        self._testcase_assign(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+            [target_a, target_b, target_c],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
         )
         self._testcase_assign(
             default.SourceWithProp,
@@ -3193,6 +3234,18 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             ],
         )
 
+        self._testcase_assign(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [target_c, target_d],
+            [
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+        )
         self._testcase_assign(
             default.SourceWithProp,
             [

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -2987,7 +2987,9 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
 
             self.client.sync(with_targets, without_targets)
 
-            self._check_multilinks_equal(with_targets.targets, expected_targets)
+            self._check_multilinks_equal(
+                with_targets.targets, expected_targets
+            )
             self._check_multilinks_equal(without_targets.targets, [])
 
             # cleanup
@@ -3463,6 +3465,15 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         self._testcase_update(
             default.SourceWithProp,
             [],
+            [target_a, target_b],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
+        self._testcase_update(
+            default.SourceWithProp,
+            [],
             [
                 default.SourceWithProp.targets.link(target_a),
                 default.SourceWithProp.targets.link(target_b),
@@ -3492,6 +3503,18 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b),
             ],
             [],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
+        self._testcase_update(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [target_a, target_b],
             [
                 default.SourceWithProp.targets.link(target_a),
                 default.SourceWithProp.targets.link(target_b),
@@ -3588,6 +3611,20 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             ],
         )
 
+        self._testcase_update(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [target_c, target_d],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+        )
         self._testcase_update(
             default.SourceWithProp,
             [
@@ -3838,6 +3875,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         self._testcase_add(
             default.SourceWithProp,
             [],
+            target_a,
+            [default.SourceWithProp.targets.link(target_a)],
+        )
+        self._testcase_add(
+            default.SourceWithProp,
+            [],
             default.SourceWithProp.targets.link(target_a),
             [default.SourceWithProp.targets.link(target_a)],
         )
@@ -3848,6 +3891,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [default.SourceWithProp.targets.link(target_a, lprop=1)],
         )
 
+        self._testcase_add(
+            default.SourceWithProp,
+            [default.SourceWithProp.targets.link(target_a)],
+            target_a,
+            [default.SourceWithProp.targets.link(target_a)],
+        )
         self._testcase_add(
             default.SourceWithProp,
             [default.SourceWithProp.targets.link(target_a)],
@@ -3881,6 +3930,21 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [default.SourceWithProp.targets.link(target_a, lprop=2)],
         )
 
+        self._testcase_add(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+            target_d,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+        )
         self._testcase_add(
             default.SourceWithProp,
             [
@@ -3981,6 +4045,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         _testcase_discard(
             default.SourceWithProp,
             [default.SourceWithProp.targets.link(target_a)],
+            target_a,
+            [],
+        )
+        _testcase_discard(
+            default.SourceWithProp,
+            [default.SourceWithProp.targets.link(target_a)],
             default.SourceWithProp.targets.link(target_a),
             [],
         )
@@ -4010,6 +4080,19 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [],
         )
 
+        _testcase_discard(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+            target_c,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
         _testcase_discard(
             default.SourceWithProp,
             [
@@ -4090,6 +4173,20 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b),
                 default.SourceWithProp.targets.link(target_c),
             ],
+            target_d,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+        )
+        _testcase_discard(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
             default.SourceWithProp.targets.link(target_d),
             [
                 default.SourceWithProp.targets.link(target_a),
@@ -4162,6 +4259,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         _testcase_remove(
             default.SourceWithProp,
             [default.SourceWithProp.targets.link(target_a)],
+            target_a,
+            [],
+        )
+        _testcase_remove(
+            default.SourceWithProp,
+            [default.SourceWithProp.targets.link(target_a)],
             default.SourceWithProp.targets.link(target_a),
             [],
         )
@@ -4191,6 +4294,19 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [],
         )
 
+        _testcase_remove(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+            target_c,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
         _testcase_remove(
             default.SourceWithProp,
             [
@@ -4345,6 +4461,15 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         self._testcase_op_iadd(
             default.SourceWithProp,
             [],
+            [target_a, target_b],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
+        self._testcase_op_iadd(
+            default.SourceWithProp,
+            [],
             [
                 default.SourceWithProp.targets.link(target_a),
                 default.SourceWithProp.targets.link(target_b),
@@ -4374,6 +4499,18 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b),
             ],
             [],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
+        self._testcase_op_iadd(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [target_a, target_b],
             [
                 default.SourceWithProp.targets.link(target_a),
                 default.SourceWithProp.targets.link(target_b),
@@ -4470,6 +4607,20 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             ],
         )
 
+        self._testcase_op_iadd(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [target_c, target_d],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+        )
         self._testcase_op_iadd(
             default.SourceWithProp,
             [
@@ -4734,6 +4885,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         _testcase_op_isub(
             default.SourceWithProp,
             [],
+            [target_a],
+            [],
+        )
+        _testcase_op_isub(
+            default.SourceWithProp,
+            [],
             [default.SourceWithProp.targets.link(target_a)],
             [],
         )
@@ -4753,6 +4910,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
         _testcase_op_isub(
             default.SourceWithProp,
             [default.SourceWithProp.targets.link(target_a)],
+            [target_a],
+            [],
+        )
+        _testcase_op_isub(
+            default.SourceWithProp,
+            [default.SourceWithProp.targets.link(target_a)],
             [default.SourceWithProp.targets.link(target_a)],
             [],
         )
@@ -4761,6 +4924,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [default.SourceWithProp.targets.link(target_a)],
             [default.SourceWithProp.targets.link(target_a, lprop=1)],
             [],
+        )
+        _testcase_op_isub(
+            default.SourceWithProp,
+            [default.SourceWithProp.targets.link(target_a)],
+            [target_b],
+            [default.SourceWithProp.targets.link(target_a)],
         )
         _testcase_op_isub(
             default.SourceWithProp,
@@ -4800,6 +4969,19 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [default.SourceWithProp.targets.link(target_a, lprop=1)],
         )
 
+        _testcase_op_isub(
+            default.Source,
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+            [target_c, target_d],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
         _testcase_op_isub(
             default.Source,
             [


### PR DESCRIPTION
Given a schema:
```
type Target;
type SourceWithProp {
    target: Target {
        lprop: int64;
    };
};
```

The following code will now sync correctly and pass assertions:
```
target = default.Target()
self.client.save(target)

source = default.SourceWithProp(target=target)
self.client.sync(source)

assert hasattr(source.target, '__linkprops__')
assert hasattr(source.target.__linkprops__, 'lprop')
assert source.target.__linkprops__.lprop is None
```

Previously, users would have to wrap the target using `default.SourceWithProp.target.link()` or a `ValueError` would be raised.

Similar behaviour has also been added to multi links.