### PR TITLE
Drop compression of test-db-cache=on

### DIFF
--- a/gel/_internal/_testbase/_base.py
+++ b/gel/_internal/_testbase/_base.py
@@ -431,7 +431,7 @@ class InstanceFixture:
     ) -> pathlib.Path | None:
         cache_info = self.get_cache_info(instance)
         if cache_info is not None:
-            fname = f"{cache_info[1]}-test-dbs.tar.zst"
+            fname = f"{cache_info[1]}-test-dbs.tar"
             return cache_info[0] / fname
         else:
             return None

--- a/gel/_internal/_testbase/_server.py
+++ b/gel/_internal/_testbase/_server.py
@@ -865,9 +865,6 @@ class ManagedInstance(BaseInstance):
                 (
                     "tar",
                     "--create",
-                    "--zstd",
-                    "--options",
-                    "zstd:compression-level=1,zstd:threads=0",
                     "--file",
                     path,
                     ".",


### PR DESCRIPTION
GNU tar doesn't seem to support `--options`, so just drop the use of
zstd.