### PR TITLE
Check kind of type in Python

### DIFF
--- a/gel/_internal/_reflection/__init__.py
+++ b/gel/_internal/_reflection/__init__.py
@@ -83,6 +83,7 @@ from ._types import (
     is_range_type,
     is_scalar_type,
     is_tuple_type,
+    kind_of_type,
 )
 
 from ._modules import (
@@ -147,4 +148,5 @@ __all__ = (
     "is_range_type",
     "is_scalar_type",
     "is_tuple_type",
+    "kind_of_type",
 )

--- a/gel/_internal/_reflection/_query.py
+++ b/gel/_internal/_reflection/_query.py
@@ -164,22 +164,18 @@ WITH
     )
 
 SELECT Type {
-    kind := assert_exists(
-        'Object' IF Type IS ObjectType ELSE
-        'Scalar' IF Type IS ScalarType ELSE
-        'Array' IF Type IS Array ELSE
-        'NamedTuple' IF Type[IS Tuple].named ?? false ELSE
-        'Tuple' IF Type IS Tuple ELSE
-        'Range' IF Type IS Range ELSE
-        'MultiRange' IF Type IS MultiRange ELSE
-        'Pseudo' IF Type IS PseudoType ELSE
-        <str>{},
-        message := "unexpected type",
-    ),
-
     id,
     builtin,
     internal,
+
+    is_object := Type IS ObjectType,
+    is_scalar := Type IS ScalarType,
+    is_array := Type IS Array,
+    is_named_tuple := Type[IS Tuple].named ?? false,
+    is_tuple := Type IS Tuple,
+    is_range := Type IS Range,
+    is_multi_range := Type IS MultiRange,
+    is_pseudo := Type IS PseudoType,
 
     name := (
         array_join(array_agg([IS ObjectType].union_of.name), ' | ')


### PR DESCRIPTION
Moves the kind of type detection from the query for reflection from EdgeQL to Python because the computed property use in the query turned out to be too costly:
```
─────────────────────────── Query ───────────────────────────
analyze
with
    module schema
select ➊  Type {
    ➋  kind := assert_exists(
        'Object' IF Type IS ObjectType ELSE
        ➌  'Scalar' IF Type IS ScalarType ELSE
        ➍  'Array' IF Type IS Array ELSE
        'NamedTuple' IF ➎  Type[IS Tuple].named ?? false ELSE
        ➏  'Tuple' IF Type IS Tuple ELSE
        ➐  'Range' IF Type IS Range ELSE
        ➑  'MultiRange' IF Type IS MultiRange ELSE
        ➒  'Pseudo' IF Type IS PseudoType ELSE
        <str>{},
        message := "unexpected type",
    ),
};

────────────────────────────────────────────── Coarse-grained Query Plan ──────────────────────────────────────────────
     │    Time        Cost  Loops   Rows  Width │ Relations
root │  2282.4   837696.69    1.0  248.0     32 │ schema::ArrayExprAlias, schema::Tuple, schema::ScalarType,
     │                                          │ schema::Range, schema::RangeExprAlias, schema::MultiRange,
     │                                          │ schema::TupleExprAlias, schema::PseudoType, schema::ObjectType,
     │                                          │ schema::MultiRangeExprAlias, schema::Array
```

vs
```
──────────────────────── Query ────────────────────────
analyze
with
    module schema
select ➊  Type {
    ➋  is_object := Type IS ObjectType,
    ➌  is_scalar := Type IS ScalarType,
    ➍  is_array := Type IS Array,
    ➎  is_named_tuple := Type[IS Tuple].named ?? false,
    ➏  is_tuple := Type IS Tuple,
    ➐  is_range := Type IS Range,
    ➑  is_multi_range := Type IS MultiRange,
    ➒  is_pseudo := Type IS PseudoType,
};

────────────────────────────────────────────── Coarse-grained Query Plan ──────────────────────────────────────────────
     │   Time     Cost  Loops   Rows  Width │ Relations
root │  210.6  6316.56    1.0  248.0     32 │ schema::ArrayExprAlias, schema::Tuple, schema::ScalarType, schema::Range,
     │                                      │ schema::RangeExprAlias, schema::MultiRange, schema::TupleExprAlias,
     │                                      │ schema::PseudoType, schema::ObjectType, schema::MultiRangeExprAlias,
     │                                      │ schema::Array
```

2 broken tests will be fixed by https://github.com/geldata/gel-python/pull/908