### PR TITLE
Change linkprops to always overwrite the existing value.

### DIFF
--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -1443,6 +1443,13 @@ class ProxyModel(
         lprops = cls.__linkprops__(**link_props)
         ll_setattr(self, "__linkprops__", lprops)
         ll_setattr(self, "_p__obj__", obj)
+
+        # Treat newly created link props as if they had all their values
+        # changed. Newly created proxy models will overwrite any existing
+        # link props.
+        lprop_names = set(self.__linkprops__.__dict__.keys())
+        ll_setattr(self.__linkprops__, '__gel_changed_fields__', lprop_names)
+
         return self
 
     def __getattribute__(self, name: str) -> Any:

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -793,10 +793,8 @@ def make_plan(
                     link_prop_variant = False
                     if prop.properties:
                         assert isinstance(val, ProxyModel)
-                        link_prop_variant = bool(
-                            get_proxy_linkprops(
-                                val
-                            ).__gel_get_changed_fields__()
+                        link_prop_variant = _linkprops_have_changes(
+                            get_proxy_linkprops(val)
                         )
 
                     if link_prop_variant:
@@ -916,7 +914,7 @@ def make_plan(
                     continue
                 assert isinstance(val, ProxyModel)
                 lprops = get_proxy_linkprops(val)
-                if not lprops.__gel_changed_fields__:
+                if not _linkprops_have_changes(lprops):
                     continue
 
                 # An existing single link has updated link props.
@@ -2041,23 +2039,22 @@ class SaveExecutor:
                     # - whether the lprop is being set to the default value
                     # - the value being set if present
                     sl_subt = [
-                        f"tuple<std::bool, bool, {arg_casts[lp_name][0]}>"
+                        f"tuple<std::bool, std::bool, {arg_casts[lp_name][0]}>"
                         for lp_name in ch.props_info
                     ]
 
                     lprop_args = (
                         (
                             lp_name in ch.props,
-                            ch.props[lp_name] == DEFAULT_VALUE,
-                            (
+                            ch.props.get(lp_name) == DEFAULT_VALUE,
+                            arg_casts[lp_name][2](
                                 None
-                                if ch.props[lp_name] == DEFAULT_VALUE
-                                else arg_casts[lp_name][2](ch.props[lp_name])
+                                if ch.props.get(lp_name) == DEFAULT_VALUE
+                                else ch.props.get(lp_name)
                             ),
                         )
                         for lp_name in ch.props_info
                     )
-                    print(ch.props)
                     sl_args = [tid, *lprop_args]
 
                     arg = add_arg(

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -22,6 +22,7 @@ from typing_extensions import TypeAliasType, dataclass_transform
 from gel._internal._qbmodel._abstract import (
     DEFAULT_VALUE,
     AbstractLinkSet,
+    AbstractGelLinkModel,
     AbstractMutableLinkSet,
     LinkSet,
     LinkWithPropsSet,
@@ -684,6 +685,18 @@ def push_refetch_existing(
             existing_objects[obj.id] = IDTracker([elst, obj])
 
 
+def _linkprops_have_changes(lprops: AbstractGelLinkModel) -> bool:
+    """Determine whether the link props have any changes.
+    This allows for simpler queries when updating links with properties.
+
+    For this purpose, DEFAULT_VALUE is considered not to be a change.
+    """
+    return bool(lprops.__gel_changed_fields__) and not all(
+        model_attr(lprops, lp_name, None) == DEFAULT_VALUE
+        for lp_name in (lprops.__gel_get_changed_fields__())
+    )
+
+
 def make_plan(
     objs: Iterable[GelModel],
     /,
@@ -1023,8 +1036,8 @@ def make_plan(
             added_proxies: Sequence[ProxyModel[GelModel]] = added  # type: ignore [assignment]
 
             # Simple case -- no link props!
-            if not prop.properties or all(
-                not get_proxy_linkprops(link).__gel_get_changed_fields__()
+            if not prop.properties or not any(
+                _linkprops_have_changes(get_proxy_linkprops(link))
                 for link in added_proxies
             ):
                 mch = MultiLinkAdd(
@@ -2023,34 +2036,57 @@ class SaveExecutor:
                         for k in ch.props_info
                     }
 
+                    # A tuple of:
+                    # - whether the lprop is being set
+                    # - whether the lprop is being set to the default value
+                    # - the value being set if present
+                    sl_subt = [
+                        f"tuple<std::bool, bool, {arg_casts[lp_name][0]}>"
+                        for lp_name in ch.props_info
+                    ]
+
+                    lprop_args = (
+                        (
+                            lp_name in ch.props,
+                            ch.props[lp_name] == DEFAULT_VALUE,
+                            (
+                                None
+                                if ch.props[lp_name] == DEFAULT_VALUE
+                                else arg_casts[lp_name][2](ch.props[lp_name])
+                            ),
+                        )
+                        for lp_name in ch.props_info
+                    )
+                    print(ch.props)
+                    sl_args = [tid, *lprop_args]
+
+                    arg = add_arg(
+                        f"tuple<std::uuid, {','.join(sl_subt)}>",
+                        sl_args,
+                    )
+
                     if ch.props.keys() == ch.props_info.keys() or for_insert:
                         # Simple case -- we overwrite all link props
 
-                        sl_subt = [arg_casts[k][0] for k in ch.props_info]
-
-                        sl_args = [
-                            tid,
-                            *(
-                                arg_casts[k][2](ch.props[k])
-                                for k in ch.props_info
-                            ),
-                        ]
-
-                        arg = add_arg(
-                            f"tuple<std::uuid, {','.join(sl_subt)}>",
-                            sl_args,
+                        # Currently we don't support __default__
+                        # Use a placeholder {}
+                        lp_assign = ", ".join(
+                            f"""
+                                @{quote_ident(lp_name)} := (
+                                    {{}}
+                                    if not {arg}.{i + 1}.0 else
+                                    {arg_casts[lp_name][1](f"{arg}.{i + 1}.2")}
+                                    if not {arg}.{i + 1}.1 else
+                                    {{}}
+                                )
+                            """
+                            for i, lp_name in enumerate(ch.props_info)
                         )
-
-                        subq_shape = [
-                            f"@{quote_ident(pname)} := "
-                            f"{arg_casts[pname][1](f'{arg}.{i}')}"
-                            for i, pname in enumerate(ch.props_info, 1)
-                        ]
 
                         shape_parts.append(
                             f"{quote_ident(ch.name)} := "
                             f"(select (<{linked_name}>{arg}.0) {{ "
-                            f"  {', '.join(subq_shape)}"
+                            f"  {lp_assign}"
                             f"}})"
                         )
 
@@ -2059,51 +2095,34 @@ class SaveExecutor:
                         # that those props that we don't update must retain
                         # their set value in the DB.
 
-                        sl_subt = [
-                            f"tuple<std::bool, {arg_casts[k][0]}>"
-                            for k in ch.props_info
-                        ]
-
-                        sl_args = [
-                            tid,
-                            *(
-                                (
-                                    k in ch.props,
-                                    arg_casts[k][2](ch.props.get(k)),
-                                )
-                                for k in ch.props_info
-                            ),
-                        ]
-
-                        arg = add_arg(
-                            f"tuple<std::uuid, {','.join(sl_subt)}>",
-                            sl_args,
-                        )
-
                         lps_to_select_shape = ",".join(
-                            f"__{quote_ident(k)} := "
-                            f"std::array_agg(@{quote_ident(k)})"
-                            for k in ch.props_info
+                            f"__{quote_ident(lp_name)} := "
+                            f"std::array_agg(@{quote_ident(lp_name)})"
+                            for lp_name in ch.props_info
                         )
 
                         lps_to_select_shape_tup = ",".join(
-                            f"__m.{quote_ident(ch.name)}.__{quote_ident(k)}"
-                            for k in ch.props_info
+                            f"__m.{quote_ident(ch.name)}.__{quote_ident(lp_name)}"
+                            for lp_name in ch.props_info
                         )
 
+                        # Currently we don't support __default__
+                        # Use a placeholder {}
                         lp_assign_reload = ", ".join(
                             f"""
-                                @{quote_ident(p)} :=
+                                @{quote_ident(lp_name)} :=
                                 (
-                                    {arg_casts[p][1](f"{arg}.{i + 1}.1")}
-                                    if {arg}.{i + 1}.0 else
                                     (
                                         select std::array_unpack(__lprops.{i})
                                         limit 1
                                     )
+                                    if not {arg}.{i + 1}.0 else
+                                    {arg_casts[lp_name][1](f"{arg}.{i + 1}.2")}
+                                    if not {arg}.{i + 1}.1 else
+                                    {{}}
                                 )
                             """
-                            for i, p in enumerate(ch.props_info)
+                            for i, lp_name in enumerate(ch.props_info)
                         )
 
                         shape_parts.append(
@@ -2173,27 +2192,35 @@ class SaveExecutor:
                     tuple_subt: list[str] | None = None
 
                     arg_casts = {
-                        k: arg_cast(ch.props_info[k].typexpr)
-                        for k in ch.props_info
+                        lp_name: arg_cast(ch.props_info[lp_name].typexpr)
+                        for lp_name in ch.props_info
                     }
 
+                    # A tuple of:
+                    # - whether the lprop is being set
+                    # - whether the lprop is being set to the default value
+                    # - the value being set if present
                     tuple_subt = [
-                        f"tuple<std::bool, {arg_casts[k][0]}>"
-                        for k in ch.props_info
+                        f"tuple<std::bool, std::bool, {arg_casts[lp_name][0]}>"
+                        for lp_name in ch.props_info
                     ]
 
                     for addo, addp in zip(
                         ch.added, ch.added_props, strict=True
                     ):
-                        link_args.append(
+                        lprop_args = (
                             (
-                                self._get_id(addo),
-                                *(
-                                    (k in addp, arg_casts[k][2](addp.get(k)))
-                                    for k in ch.props_info
+                                lp_name in addp,
+                                addp.get(lp_name) == DEFAULT_VALUE,
+                                arg_casts[lp_name][2](
+                                    None
+                                    if addp.get(lp_name) == DEFAULT_VALUE
+                                    else addp.get(lp_name)
                                 ),
                             )
+                            for lp_name in ch.props_info
                         )
+                        link_args.append((self._get_id(addo), *lprop_args))
 
                     arg = add_arg(
                         f"array<tuple<std::uuid, {','.join(tuple_subt)}>>",
@@ -2201,10 +2228,19 @@ class SaveExecutor:
                     )
 
                     if new_link:
+                        # Currently we don't support __default__
+                        # Use a placeholder {}
                         lp_assign = ", ".join(
-                            f"@{quote_ident(p)} := "
-                            f"{arg_casts[p][1](f'__tup.{i + 1}.1')}"
-                            for i, p in enumerate(ch.props_info)
+                            f"""
+                                @{quote_ident(lp_name)} := (
+                                    {{}}
+                                    if not __tup.{i + 1}.0 else
+                                    {arg_casts[lp_name][1](f"__tup.{i + 1}.2")}
+                                    if not __tup.{i + 1}.1 else
+                                    {{}}
+                                )
+                            """
+                            for i, lp_name in enumerate(ch.props_info)
                         )
 
                         shape_parts.append(
@@ -2215,25 +2251,29 @@ class SaveExecutor:
                             f"{lp_assign}"
                             f"}})))"
                         )
+
                     else:
                         lps_to_select_shape = ",".join(
-                            f"std::array_agg(__m@{quote_ident(k)})"
-                            for k in ch.props_info
+                            f"std::array_agg(__m@{quote_ident(lp_name)})"
+                            for lp_name in ch.props_info
                         )
 
+                        # Currently we don't support __default__
+                        # Use a placeholder {}
                         lp_assign_reload = ", ".join(
                             f"""
-                                @{quote_ident(p)} :=
-                                (
-                                    {arg_casts[p][1](f"__tup.{i + 1}.1")}
-                                    if __tup.{i + 1}.0 else
+                                @{quote_ident(lp_name)} := (
                                     (
                                         select std::array_unpack(__lprops.{i})
                                         limit 1
                                     )
+                                    if not __tup.{i + 1}.0 else
+                                    {arg_casts[lp_name][1](f"__tup.{i + 1}.2")}
+                                    if not __tup.{i + 1}.1 else
+                                    {{}}
                                 )
                             """
-                            for i, p in enumerate(ch.props_info)
+                            for i, lp_name in enumerate(ch.props_info)
                         )
 
                         # Re `__lprops` below -- currently this is just about

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -3491,12 +3491,10 @@ class TestModelGenerator(tb.ModelTestCase):
         # Test link props on multi links -- specifically that we support:
         #
         # - setting some of the props
+        # - updating one prop to a new value,
+        # - resetting one prop to None
         #
-        # - updating one prop with one value,
-        #   but the other props in the db must survive
-        #
-        # - resetting one prop to None - with it actually resetting to
-        #   an empty set in the DB and other props surviving
+        # Unspecified props are reset to None. This imitates python semantics.
 
         import json
         from typing import Any
@@ -3559,7 +3557,7 @@ class TestModelGenerator(tb.ModelTestCase):
         check(
             {
                 "members": [
-                    {"name": "Alice", "@rank": 1000, "@role": "lead"},
+                    {"name": "Alice", "@rank": 1000, "@role": None},
                     {"name": "Billie", "@rank": 2, "@role": None},
                 ]
             }
@@ -3578,7 +3576,7 @@ class TestModelGenerator(tb.ModelTestCase):
         check(
             {
                 "members": [
-                    {"name": "Alice", "@rank": None, "@role": "lead"},
+                    {"name": "Alice", "@rank": None, "@role": None},
                     {"name": "Billie", "@rank": 2, "@role": None},
                 ]
             }
@@ -5065,8 +5063,7 @@ class TestModelGenerator(tb.ModelTestCase):
 
         # Fetch the team
         team1 = self.client.get(default.Team.filter(name="Taco Wizards"))
-        # Merge this new link (rank is "unset", so we don't expect it to
-        # change)
+        # Merge this new link (rank is "unset", so we expect it to reset)
         team1.members.add(default.Team.members.link(u, role="sorceress"))
         self.client.save(team1)
 
@@ -5077,7 +5074,7 @@ class TestModelGenerator(tb.ModelTestCase):
 
         member = list(team2.members)[0]
         self.assertEqual(member.name, "Zoe")
-        self.assertEqual(member.__linkprops__.rank, 1)
+        self.assertEqual(member.__linkprops__.rank, None)
         self.assertEqual(member.__linkprops__.role, "sorceress")
 
     @tb.xfail

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -2684,6 +2684,13 @@ class TestModelSyncSingleLink(tb.ModelTestCase):
                 lprop: int64;
             };
         };
+        type SourceWithPropWithDefault {
+            target: Target {
+                lprop: int64 {
+                    default := -1;
+                };
+            };
+        };
 
         type Target2 extending Target;
         type SourceWithDmlDefault {
@@ -2813,6 +2820,36 @@ class TestModelSyncSingleLink(tb.ModelTestCase):
             default.SourceWithDmlDefault,
             target,
             dml_default_type=default.Target2,
+        )
+
+        # Linkprop with default
+        _testcase(
+            default.SourceWithPropWithDefault,
+            target,
+            expected_target=default.SourceWithPropWithDefault.target.link(
+                target, lprop=-1
+            ),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target),
+            expected_target=default.SourceWithPropWithDefault.target.link(
+                target, lprop=-1
+            ),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target, lprop=None),
+            expected_target=default.SourceWithPropWithDefault.target.link(
+                target, lprop=None
+            ),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target, lprop=1),
+            expected_target=default.SourceWithPropWithDefault.target.link(
+                target, lprop=1
+            ),
         )
 
     def test_model_sync_single_link_02(self):
@@ -2959,6 +2996,92 @@ class TestModelSyncSingleLink(tb.ModelTestCase):
             default.SourceWithProp,
             default.SourceWithProp.target.link(target_a, lprop=1),
             default.SourceWithProp.target.link(target_a, lprop=1),
+        )
+
+        # Linkprop with default
+        _testcase(
+            default.SourceWithPropWithDefault,
+            None,
+            target_a,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=-1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            None,
+            default.SourceWithPropWithDefault.target.link(target_a),
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=-1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            None,
+            default.SourceWithPropWithDefault.target.link(
+                target_a, lprop=None
+            ),
+            default.SourceWithPropWithDefault.target.link(
+                target_a, lprop=None
+            ),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            None,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=1),
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            target_a,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=-1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            default.SourceWithPropWithDefault.target.link(target_a),
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=-1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            default.SourceWithPropWithDefault.target.link(
+                target_a, lprop=None
+            ),
+            default.SourceWithPropWithDefault.target.link(
+                target_a, lprop=None
+            ),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=1),
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            target_b,
+            default.SourceWithPropWithDefault.target.link(target_b, lprop=-1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            default.SourceWithPropWithDefault.target.link(target_b),
+            default.SourceWithPropWithDefault.target.link(target_b, lprop=-1),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            default.SourceWithPropWithDefault.target.link(
+                target_b, lprop=None
+            ),
+            default.SourceWithPropWithDefault.target.link(
+                target_b, lprop=None
+            ),
+        )
+        _testcase(
+            default.SourceWithPropWithDefault,
+            default.SourceWithPropWithDefault.target.link(target_a, lprop=9),
+            default.SourceWithPropWithDefault.target.link(target_b, lprop=1),
+            default.SourceWithPropWithDefault.target.link(target_b, lprop=1),
         )
 
     def _testcase_03(

--- a/tests/test_model_sync.py
+++ b/tests/test_model_sync.py
@@ -3679,20 +3679,19 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             ],
             [],
         )
-        # Fail, moved to test_model_sync_multi_link_02a
-        # self._testcase_assign(
-        #     default.SourceWithProp,
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b, lprop=2),
-        #         default.SourceWithProp.targets.link(target_c, lprop=3),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a),
-        #         default.SourceWithProp.targets.link(target_b),
-        #         default.SourceWithProp.targets.link(target_c),
-        #     ],
-        # )
+        self._testcase_assign(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b, lprop=2),
+                default.SourceWithProp.targets.link(target_c, lprop=3),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+            ],
+        )
         self._testcase_assign(
             default.SourceWithProp,
             [
@@ -3779,31 +3778,6 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [
                 default.SourceWithProp.targets.link(target_c),
                 default.SourceWithProp.targets.link(target_d),
-            ],
-        )
-
-    @tb.xfail
-    def test_model_sync_multi_link_02a(self):
-        from models.TestModelSyncMultiLink import default
-
-        target_a = default.Target()
-        target_b = default.Target()
-        target_c = default.Target()
-        target_d = default.Target()
-        self.client.save(target_a, target_b, target_c, target_d)
-
-        # Fail, linkprop not reset
-        self._testcase_assign(
-            default.SourceWithProp,
-            [
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b, lprop=2),
-                default.SourceWithProp.targets.link(target_c, lprop=3),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_a),
-                default.SourceWithProp.targets.link(target_b),
-                default.SourceWithProp.targets.link(target_c),
             ],
         )
 
@@ -4244,22 +4218,21 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b, lprop=2),
             ],
         )
-        # Fail, moved to test_model_sync_multi_link_04a
-        # self._testcase_update(
-        #     default.SourceWithProp,
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b, lprop=2),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a),
-        #         default.SourceWithProp.targets.link(target_b),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a),
-        #         default.SourceWithProp.targets.link(target_b),
-        #     ],
-        # )
+        self._testcase_update(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b, lprop=2),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
         self._testcase_update(
             default.SourceWithProp,
             [
@@ -4379,26 +4352,25 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_d),
             ],
         )
-        # Fail, moved to test_model_sync_multi_link_04b
-        # self._testcase_update(
-        #     default.SourceWithProp,
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b, lprop=2),
-        #         default.SourceWithProp.targets.link(target_c, lprop=3),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_b),
-        #         default.SourceWithProp.targets.link(target_c),
-        #         default.SourceWithProp.targets.link(target_d),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b),
-        #         default.SourceWithProp.targets.link(target_c),
-        #         default.SourceWithProp.targets.link(target_d),
-        #     ],
-        # )
+        self._testcase_update(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b, lprop=2),
+                default.SourceWithProp.targets.link(target_c, lprop=3),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+        )
         self._testcase_update(
             default.SourceWithProp,
             [
@@ -4435,64 +4407,6 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b, lprop=4),
                 default.SourceWithProp.targets.link(target_c, lprop=5),
                 default.SourceWithProp.targets.link(target_d, lprop=6),
-            ],
-        )
-
-    @tb.xfail
-    def test_model_sync_multi_link_04a(self):
-        from models.TestModelSyncMultiLink import default
-
-        target_a = default.Target()
-        target_b = default.Target()
-        target_c = default.Target()
-        target_d = default.Target()
-        self.client.save(target_a, target_b, target_c, target_d)
-
-        self._testcase_update(
-            default.SourceWithProp,
-            [
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b, lprop=2),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_a),
-                default.SourceWithProp.targets.link(target_b),
-            ],
-            [
-                # Fail, linkprops not reset
-                default.SourceWithProp.targets.link(target_a),
-                default.SourceWithProp.targets.link(target_b),
-            ],
-        )
-
-    @tb.xfail
-    def test_model_sync_multi_link_04b(self):
-        from models.TestModelSyncMultiLink import default
-
-        target_a = default.Target()
-        target_b = default.Target()
-        target_c = default.Target()
-        target_d = default.Target()
-        self.client.save(target_a, target_b, target_c, target_d)
-
-        self._testcase_update(
-            default.SourceWithProp,
-            [
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b, lprop=2),
-                default.SourceWithProp.targets.link(target_c, lprop=3),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_b),
-                default.SourceWithProp.targets.link(target_c),
-                default.SourceWithProp.targets.link(target_d),
-            ],
-            [
-                # Fail, linkprops not reset
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b),
-                default.SourceWithProp.targets.link(target_c),
-                default.SourceWithProp.targets.link(target_d),
             ],
         )
 
@@ -5077,13 +4991,12 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
             [default.SourceWithProp.targets.link(target_a, lprop=1)],
         )
 
-        # Fail, moved to test_model_sync_multi_link_05a
-        # self._testcase_add(
-        #     default.SourceWithProp,
-        #     [default.SourceWithProp.targets.link(target_a, lprop=1)],
-        #     default.SourceWithProp.targets.link(target_a),
-        #     [default.SourceWithProp.targets.link(target_a)],
-        # )
+        self._testcase_add(
+            default.SourceWithProp,
+            [default.SourceWithProp.targets.link(target_a, lprop=1)],
+            default.SourceWithProp.targets.link(target_a),
+            [default.SourceWithProp.targets.link(target_a)],
+        )
         self._testcase_add(
             default.SourceWithProp,
             [default.SourceWithProp.targets.link(target_a, lprop=1)],
@@ -5141,24 +5054,6 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_c),
                 default.SourceWithProp.targets.link(target_d, lprop=4),
             ],
-        )
-
-    @tb.xfail
-    def test_model_sync_multi_link_05a(self):
-        from models.TestModelSyncMultiLink import default
-
-        target_a = default.Target()
-        target_b = default.Target()
-        target_c = default.Target()
-        target_d = default.Target()
-        self.client.save(target_a, target_b, target_c, target_d)
-
-        # Fail, linkprop not reset
-        self._testcase_add(
-            default.SourceWithProp,
-            [default.SourceWithProp.targets.link(target_a, lprop=1)],
-            default.SourceWithProp.targets.link(target_a),
-            [default.SourceWithProp.targets.link(target_a)],
         )
 
     @tb.xfail  # multilink linkprops not refetched
@@ -6074,22 +5969,21 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b, lprop=2),
             ],
         )
-        # Fail, moved to test_model_sync_multi_link_08a
-        # self._testcase_op_iadd(
-        #     default.SourceWithProp,
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b, lprop=2),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a),
-        #         default.SourceWithProp.targets.link(target_b),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a),
-        #         default.SourceWithProp.targets.link(target_b),
-        #     ],
-        # )
+        self._testcase_op_iadd(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b, lprop=2),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a),
+                default.SourceWithProp.targets.link(target_b),
+            ],
+        )
         self._testcase_op_iadd(
             default.SourceWithProp,
             [
@@ -6209,26 +6103,25 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_d),
             ],
         )
-        # Fail, moved to test_model_sync_multi_link_08b
-        # self._testcase_op_iadd(
-        #     default.SourceWithProp,
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b, lprop=2),
-        #         default.SourceWithProp.targets.link(target_c, lprop=3),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_b),
-        #         default.SourceWithProp.targets.link(target_c),
-        #         default.SourceWithProp.targets.link(target_d),
-        #     ],
-        #     [
-        #         default.SourceWithProp.targets.link(target_a, lprop=1),
-        #         default.SourceWithProp.targets.link(target_b),
-        #         default.SourceWithProp.targets.link(target_c),
-        #         default.SourceWithProp.targets.link(target_d),
-        #     ],
-        # )
+        self._testcase_op_iadd(
+            default.SourceWithProp,
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b, lprop=2),
+                default.SourceWithProp.targets.link(target_c, lprop=3),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+            [
+                default.SourceWithProp.targets.link(target_a, lprop=1),
+                default.SourceWithProp.targets.link(target_b),
+                default.SourceWithProp.targets.link(target_c),
+                default.SourceWithProp.targets.link(target_d),
+            ],
+        )
         self._testcase_op_iadd(
             default.SourceWithProp,
             [
@@ -6265,64 +6158,6 @@ class TestModelSyncMultiLink(tb.ModelTestCase):
                 default.SourceWithProp.targets.link(target_b, lprop=4),
                 default.SourceWithProp.targets.link(target_c, lprop=5),
                 default.SourceWithProp.targets.link(target_d, lprop=6),
-            ],
-        )
-
-    @tb.xfail
-    def test_model_sync_multi_link_08a(self):
-        from models.TestModelSyncMultiLink import default
-
-        target_a = default.Target()
-        target_b = default.Target()
-        target_c = default.Target()
-        target_d = default.Target()
-        self.client.save(target_a, target_b, target_c, target_d)
-
-        # Fail, linkprop not reset
-        self._testcase_op_iadd(
-            default.SourceWithProp,
-            [
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b, lprop=2),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_a),
-                default.SourceWithProp.targets.link(target_b),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_a),
-                default.SourceWithProp.targets.link(target_b),
-            ],
-        )
-
-    @tb.xfail
-    def test_model_sync_multi_link_08b(self):
-        from models.TestModelSyncMultiLink import default
-
-        target_a = default.Target()
-        target_b = default.Target()
-        target_c = default.Target()
-        target_d = default.Target()
-        self.client.save(target_a, target_b, target_c, target_d)
-
-        # Fail, linkprop not reset
-        self._testcase_op_iadd(
-            default.SourceWithProp,
-            [
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b, lprop=2),
-                default.SourceWithProp.targets.link(target_c, lprop=3),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_b),
-                default.SourceWithProp.targets.link(target_c),
-                default.SourceWithProp.targets.link(target_d),
-            ],
-            [
-                default.SourceWithProp.targets.link(target_a, lprop=1),
-                default.SourceWithProp.targets.link(target_b),
-                default.SourceWithProp.targets.link(target_c),
-                default.SourceWithProp.targets.link(target_d),
             ],
         )
 


### PR DESCRIPTION
close #885

Given a schema:
```edgeql
type Target;
type SourceWithProp {
    multi targets: Target {
        lprop: int64;
    };
};
```

the following code was failing its assertion:
```py
target_a = default.Target()
self.client.save(target_a)

source = default.SourceWithProp(
    targets=[default.SourceWithProp.targets.link(target_a, lprop=1)]
)
self.client.save(source)

source.targets = [default.SourceWithProp.targets.link(target_a)]
self.client.sync(source)

assert all(
    target.__linkprops__.lprop == None
    for target in source.targets
)  # fail
```