### PR TITLE
Prevent test discovery from loading models

### DIFF
--- a/gel/_internal/_testbase/_models.py
+++ b/gel/_internal/_testbase/_models.py
@@ -358,7 +358,13 @@ class BaseModelTestCase(BranchTestCase):
         models_dir = test_dir / "models"
         models_dir.mkdir(exist_ok=True)
         # Make sure the base "models" directory has an __init__.py
-        (models_dir / "__init__.py").touch()
+        (models_dir / "__init__.py").write_text(
+            textwrap.dedent('''\
+            # Prevent unittest from recursing into the models
+            def load_tests(*args, **kwargs):
+                return None
+        ''')
+        )
         # and py.typed
         (models_dir / "py.typed").touch()
 


### PR DESCRIPTION
Since we started putting models in tests/models, unittest (which
geltest uses also for this) test discovery will go and recursively
import models that are sitting around between test runs. This is rough
as some/all of them are about to be blown away and regenerated.

If we just switched from some branch making interesting changes, the
imports might fail.

unittest has a `load_tests` protocol that we can use to take charge of
our own test loading for a package... and then not do any.