### PR TITLE
Fix some decoding of subsubtypes in general and std::Object in particular

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -4352,6 +4352,9 @@ class GeneratedSchemaModule(BaseGeneratedModule):
         include_tname: bool = False,
     ) -> None:
         if include_tname:
+            if objtype.name in CORE_OBJECTS:
+                self.write('__gel_is_canonical__ = True')
+
             type_name = objtype.schemapath
             literal = self.import_name("typing", "Literal")
             field = self.import_name("pydantic", "Field")
@@ -4728,6 +4731,7 @@ class GeneratedSchemaModule(BaseGeneratedModule):
             ),
         ):
             self.write(f'"""type {objtype.name}"""')
+            self.write('__gel_is_canonical__ = True')
             self.write()
             pointers = _get_object_type_body(objtype)
             if pointers:
@@ -4740,9 +4744,6 @@ class GeneratedSchemaModule(BaseGeneratedModule):
                         localns=localns,
                     )
                     self._write_model_attribute(ptr.name, ptr_type)
-            else:
-                self.write("pass")
-                self.write()
 
     def _write_model_attribute(self, name: str, anno: str) -> None:
         decl = f"{name}: {anno}"

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -35,6 +35,11 @@ class GelSchemaMetadata:
     class __gel_reflection__:  # noqa: N801
         name: ClassVar[SchemaPath]
 
+    # Whether this class is a "canonical" type - that is, the primary
+    # representation of a database type, not an internal __shape__ class,
+    # or a user-defined subtype, or anything else.
+    __gel_is_canonical__: ClassVar[bool]
+
 
 class GelSourceMetadata(GelSchemaMetadata):
     class __gel_reflection__(GelSchemaMetadata.__gel_reflection__):  # noqa: N801

--- a/gel/_internal/_qbmodel/_abstract/_base.py
+++ b/gel/_internal/_qbmodel/_abstract/_base.py
@@ -167,30 +167,13 @@ class AbstractGelModelMeta(GelTypeMeta):
         reflection = cls.__gel_reflection__
         if (
             # The class registry only tracks the canonical base instances,
-            # which are the ones with a base that directly declares 'tname__'
-            # but do not declare it themselves.
-            #
-            # Eg.
-            #
-            #   default/__init__.py :
-            #     class Foo(base_shapes.Foo):
-            #       ...
-            #
-            #   __shapes__/default/__init__.py :
-            #     class Foo(__Foo_default_shape__, __gel_shape__="RequiredId"):
-            #       tname__: Literal["default::Foo"] = Field(
-            #         "default::Foo", alias="__tname__")
-            #
-            # The user facing default.Foo does not directly declare tname__,
-            # but base_shapes.Foo does.
-            #
-            # For a derived `type Bar extending Foo`, default.Bar does not
-            # directly declare tname__, but base_shapes.Bar does.
+            # which are declared with __gel_is_canonical__ = True.
             (tname := getattr(reflection, "name", None)) is not None
-            and any('tname__' in base.__dict__ for base in bases)
-            and 'tname__' not in namespace
+            and namespace.get('__gel_is_canonical__')
         ):
             mcls.__gel_class_registry__[str(tname)] = cls
+        else:
+            cls.__gel_is_canonical__ = False
         cls.__gel_shape__ = __gel_shape__
         return cls
 

--- a/tests/dbsetup/orm.gel
+++ b/tests/dbsetup/orm.gel
@@ -82,7 +82,7 @@ type Party extending ExclusivelyNamed {
 
 # Object with required multi link, has link props
 type Raid extending ExclusivelyNamed {
-    required multi members: User {
+    required multi members: Named {
         role: str;
         rank: int64;
     };

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -261,7 +261,6 @@ class TestModelGeneratorMain(tb.ModelTestCase):
         self.assertIsInstance(user, default.User)
         self.assertIsInstance(user, default.CustomUser)
 
-    @tb.xfail("links to std::Object don't decoded to the object's actual type")
     def test_modelgen_07(self):
         from models.orm import default, std
 
@@ -1375,7 +1374,6 @@ class TestModelGeneratorMain(tb.ModelTestCase):
         self.assertPydanticPickles(t)
         self.assertPydanticSerializes(t)
 
-    @tb.xfail("links to std::Object don't decoded to the object's actual type")
     def test_modelgen_pydantic_apis_11e(self):
         # Test model_dump() and model_dump_json() on models;
         # test *single required* link serialization in all combinations
@@ -1392,7 +1390,6 @@ class TestModelGeneratorMain(tb.ModelTestCase):
         self.assertPydanticPickles(t)
         self.assertPydanticSerializes(t)
 
-    @tb.xfail("links to std::Object don't decoded to the object's actual type")
     def test_modelgen_pydantic_apis_11f(self):
         # Test model_dump() and model_dump_json() on models;
         # test *single required* link serialization in all combinations


### PR DESCRIPTION
I ran into a few things here:
 - The object.pyx code to handle decoding to subclasses only looks
   at __subclasses__, and so misses grandchildren types. I clearly
   remember thinking about this and testing the grandchild case,
   but apparently I missed something there.
 - Descendants of std::Object in particular get immediately screwy,
   because user-facing types don't inherit from std::Object directly,
   but instead their __shapes__ do.
 - The new "`tname__` in `__shapes__`" mechanism (#926) was putting
   wrong stuff in the map in some cases.

My approach is to explicitly indicate which classes should be
considered the canonical decoding classes with a `__gel_is_canonical__
= True` field on the class. And for now, I'm populating it explicitly,
though we can probably write a bunch of nasty logic to figure it out too.