### PR TITLE
Add ParametricTypeName to support names of types like arrays and tuples.

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -1152,7 +1152,7 @@ class BaseGeneratedModule:
             obj_name = sobj.schemapath.as_python_code(sp_clsname, ptn_clsname)
             self.write(f"name = {obj_name}")
             if isinstance(sobj, reflection.Type):
-                type_name = sobj.type_name.as_python_code(
+                type_name = sobj.get_type_name(self._types).as_python_code(
                     sp_clsname, ptn_clsname
                 )
                 self.write(f"type_name = {type_name}")
@@ -1197,7 +1197,7 @@ class BaseGeneratedModule:
             obj_name = objtype.schemapath.as_python_code(
                 sp_clsname, ptn_clsname
             )
-            type_name = objtype.type_name.as_python_code(
+            type_name = objtype.get_type_name(self._types).as_python_code(
                 sp_clsname, ptn_clsname
             )
             self.write(f"name = {obj_name}")
@@ -1319,10 +1319,9 @@ class BaseGeneratedModule:
         target_type = self._types[ptr.target_id]
         kwargs: dict[str, str] = {
             "name": repr(ptr.name),
-            "type": target_type.schemapath.as_python_code(
+            "type": target_type.get_type_name(self._types).as_python_code(
                 classes["SchemaPath"], classes["ParametricTypeName"]
             ),
-            "typexpr": repr(target_type.type_name.as_quoted_schema_name()),
             "kind": f"{classes['PointerKind']}({str(ptr.kind)!r})",
             "cardinality": f"{classes['Cardinality']}({str(ptr.card)!r})",
             "computed": str(ptr.is_computed),

--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -1302,7 +1302,7 @@ class BaseGeneratedModule:
         kwargs: dict[str, str] = {
             "name": repr(ptr.name),
             "type": target_type.schemapath.as_code(classes["SchemaPath"]),
-            "typexpr": repr(target_type.edgeql),
+            "typexpr": repr(target_type.type_name.as_quoted_schema_name()),
             "kind": f"{classes['PointerKind']}({str(ptr.kind)!r})",
             "cardinality": f"{classes['Cardinality']}({str(ptr.card)!r})",
             "computed": str(ptr.is_computed),

--- a/gel/_internal/_edgeql/_schema.py
+++ b/gel/_internal/_edgeql/_schema.py
@@ -11,6 +11,8 @@ import re
 import uuid
 
 from gel._internal._polyfills._strenum import StrEnum
+from gel._internal._schemapath import SchemaPath, TypeName
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -74,46 +76,46 @@ def _get_type_id(name: str, cls: str) -> uuid.UUID:
 
 def get_array_type_id_and_name(
     element: str,
-) -> tuple[uuid.UUID, str]:
+) -> tuple[uuid.UUID, TypeName]:
     type_id = _get_type_id(f"array<{_mangle_name(element)}>", "Array")
     type_name = f"array<{element}>"
-    return type_id, type_name
+    return type_id, SchemaPath(type_name)
 
 
 def get_range_type_id_and_name(
     element: str,
-) -> tuple[uuid.UUID, str]:
+) -> tuple[uuid.UUID, TypeName]:
     type_id = _get_type_id(f"range<{_mangle_name(element)}>", "Range")
     type_name = f"range<{element}>"
-    return type_id, type_name
+    return type_id, SchemaPath(type_name)
 
 
 def get_multirange_type_id_and_name(
     element: str,
-) -> tuple[uuid.UUID, str]:
+) -> tuple[uuid.UUID, TypeName]:
     type_id = _get_type_id(
         f"multirange<{_mangle_name(element)}>", "MultiRange"
     )
     type_name = f"multirange<{element}>"
-    return type_id, type_name
+    return type_id, SchemaPath(type_name)
 
 
 def get_tuple_type_id_and_name(
     elements: Iterable[str],
-) -> tuple[uuid.UUID, str]:
+) -> tuple[uuid.UUID, TypeName]:
     body = ", ".join(elements)
     type_id = _get_type_id(f"tuple<{_mangle_name(body)}>", "Tuple")
     type_name = f"tuple<{body}>"
-    return type_id, type_name
+    return type_id, SchemaPath(type_name)
 
 
 def get_named_tuple_type_id_and_name(
     elements: dict[str, str],
-) -> tuple[uuid.UUID, str]:
+) -> tuple[uuid.UUID, TypeName]:
     body = ", ".join(f"{n}:{t}" for n, t in elements.items())
     type_id = _get_type_id(f"tuple<{_mangle_name(body)}>", "Tuple")
     type_name = f"tuple<{body}>"
-    return type_id, type_name
+    return type_id, SchemaPath(type_name)
 
 
 __all__ = (

--- a/gel/_internal/_edgeql/_schema.py
+++ b/gel/_internal/_edgeql/_schema.py
@@ -120,8 +120,8 @@ def get_named_tuple_type_id_and_name(
 ) -> tuple[uuid.UUID, TypeName]:
     body = ", ".join(f"{n}:{t.as_schema_name()}" for n, t in elements.items())
     type_id = _get_type_id(f"tuple<{_mangle_name(body)}>", "Tuple")
-    type_name = f"tuple<{body}>"
-    return type_id, SchemaPath(type_name)
+    type_name = ParametricTypeName(SchemaPath("std", "tuple"), elements)
+    return type_id, type_name
 
 
 __all__ = (

--- a/gel/_internal/_edgeql/_schema.py
+++ b/gel/_internal/_edgeql/_schema.py
@@ -5,17 +5,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final
+from typing import final
 
 import re
 import uuid
 
 from gel._internal._polyfills._strenum import StrEnum
-from gel._internal._schemapath import SchemaPath, TypeName
-
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from gel._internal._schemapath import ParametricTypeName, SchemaPath, TypeName
 
 
 @final
@@ -75,44 +71,54 @@ def _get_type_id(name: str, cls: str) -> uuid.UUID:
 
 
 def get_array_type_id_and_name(
-    element: str,
+    element: TypeName,
 ) -> tuple[uuid.UUID, TypeName]:
-    type_id = _get_type_id(f"array<{_mangle_name(element)}>", "Array")
-    type_name = f"array<{element}>"
-    return type_id, SchemaPath(type_name)
+    type_id = _get_type_id(
+        f"array<{_mangle_name(element.as_schema_name())}>", "Array"
+    )
+    type_name = ParametricTypeName(SchemaPath("std", "array"), [element])
+    return type_id, type_name
 
 
 def get_range_type_id_and_name(
-    element: str,
+    element: TypeName,
 ) -> tuple[uuid.UUID, TypeName]:
-    type_id = _get_type_id(f"range<{_mangle_name(element)}>", "Range")
-    type_name = f"range<{element}>"
-    return type_id, SchemaPath(type_name)
+    type_id = _get_type_id(
+        f"range<{_mangle_name(element.as_schema_name())}>", "Range"
+    )
+    type_name = ParametricTypeName(
+        SchemaPath("std", "range"),
+        [element],
+    )
+    return type_id, type_name
 
 
 def get_multirange_type_id_and_name(
-    element: str,
+    element: TypeName,
 ) -> tuple[uuid.UUID, TypeName]:
     type_id = _get_type_id(
-        f"multirange<{_mangle_name(element)}>", "MultiRange"
+        f"multirange<{_mangle_name(element.as_schema_name())}>", "MultiRange"
     )
-    type_name = f"multirange<{element}>"
-    return type_id, SchemaPath(type_name)
+    type_name = ParametricTypeName(
+        SchemaPath("std", "range"),
+        [element],
+    )
+    return type_id, type_name
 
 
 def get_tuple_type_id_and_name(
-    elements: Iterable[str],
+    elements: list[TypeName],
 ) -> tuple[uuid.UUID, TypeName]:
-    body = ", ".join(elements)
+    body = ", ".join(element.as_schema_name() for element in elements)
     type_id = _get_type_id(f"tuple<{_mangle_name(body)}>", "Tuple")
-    type_name = f"tuple<{body}>"
-    return type_id, SchemaPath(type_name)
+    type_name = ParametricTypeName(SchemaPath("std", "tuple"), elements)
+    return type_id, type_name
 
 
 def get_named_tuple_type_id_and_name(
-    elements: dict[str, str],
+    elements: dict[str, TypeName],
 ) -> tuple[uuid.UUID, TypeName]:
-    body = ", ".join(f"{n}:{t}" for n, t in elements.items())
+    body = ", ".join(f"{n}:{t.as_schema_name()}" for n, t in elements.items())
     type_id = _get_type_id(f"tuple<{_mangle_name(body)}>", "Tuple")
     type_name = f"tuple<{body}>"
     return type_id, SchemaPath(type_name)

--- a/gel/_internal/_qb/_abstract.py
+++ b/gel/_internal/_qb/_abstract.py
@@ -19,7 +19,7 @@ from gel._internal import _edgeql
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping
-    from gel._internal._schemapath import SchemaPath
+    from gel._internal._schemapath import TypeName
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -89,7 +89,7 @@ class Expr(Node):
     def precedence(self) -> _edgeql.Precedence: ...
 
     @abc.abstractproperty
-    def type(self) -> SchemaPath: ...
+    def type(self) -> TypeName: ...
 
     @abc.abstractmethod
     def __edgeql_expr__(self, *, ctx: ScopeContext) -> str: ...
@@ -100,10 +100,10 @@ class Expr(Node):
 
 @dataclass(kw_only=True, frozen=True)
 class TypedExpr(Expr):
-    type_: SchemaPath
+    type_: TypeName
 
     @property
-    def type(self) -> SchemaPath:
+    def type(self) -> TypeName:
         return self.type_
 
 
@@ -499,7 +499,7 @@ class ImplicitIteratorStmt(IteratorExpr, Stmt):
     """Base class for statements that are implicit iterators"""
 
     @property
-    def type(self) -> SchemaPath:
+    def type(self) -> TypeName:
         return self.iter_expr.type
 
     @property

--- a/gel/_internal/_qb/_expressions.py
+++ b/gel/_internal/_qb/_expressions.py
@@ -929,7 +929,7 @@ def get_object_type_splat(cls: type[GelTypeMetadata]) -> Shape:
     shape = _type_splat_cache.get(cls)
     if shape is None:
         reflection = cls.__gel_reflection__
-        shape = Shape.splat(source=reflection.name)
+        shape = Shape.splat(source=reflection.type_name)
         _type_splat_cache[cls] = shape
     return shape
 

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GelPointerReflection:
     name: str
-    type: SchemaPath
-    typexpr: str
+    type: TypeName
     kind: _edgeql.PointerKind
     cardinality: _edgeql.Cardinality
     computed: bool

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -10,7 +10,7 @@ import dataclasses
 if TYPE_CHECKING:
     import abc
     from gel._internal import _edgeql
-    from gel._internal._schemapath import SchemaPath
+    from gel._internal._schemapath import SchemaPath, TypeName
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -33,7 +33,7 @@ class GelReflectionProto(Protocol):
 
 class GelSchemaMetadata:
     class __gel_reflection__:  # noqa: N801
-        name: ClassVar[SchemaPath]
+        name: ClassVar[TypeName]
 
     # Whether this class is a "canonical" type - that is, the primary
     # representation of a database type, not an internal __shape__ class,

--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -33,7 +33,7 @@ class GelReflectionProto(Protocol):
 
 class GelSchemaMetadata:
     class __gel_reflection__:  # noqa: N801
-        name: ClassVar[TypeName]
+        name: ClassVar[SchemaPath]
 
     # Whether this class is a "canonical" type - that is, the primary
     # representation of a database type, not an internal __shape__ class,
@@ -47,7 +47,8 @@ class GelSourceMetadata(GelSchemaMetadata):
 
 
 class GelTypeMetadata(GelSchemaMetadata):
-    pass
+    class __gel_reflection__(GelSchemaMetadata.__gel_reflection__):  # noqa: N801
+        type_name: ClassVar[TypeName]
 
 
 if TYPE_CHECKING:

--- a/gel/_internal/_qbmodel/_abstract/_base.py
+++ b/gel/_internal/_qbmodel/_abstract/_base.py
@@ -202,7 +202,7 @@ class AbstractGelModel(
 
     @classmethod
     def __edgeql_qb_expr__(cls) -> _qb.Expr:  # pyright: ignore [reportIncompatibleMethodOverride]
-        this_type = cls.__gel_reflection__.name
+        this_type = cls.__gel_reflection__.type_name
         return _qb.SchemaSet(type_=this_type)
 
     if TYPE_CHECKING:
@@ -255,8 +255,8 @@ def maybe_collapse_object_type_variant_union(
             # Not an object type reflection union at all!
             return None
         if typename is None:
-            typename = union_arg.__gel_reflection__.name
-        elif typename != union_arg.__gel_reflection__.name:
+            typename = union_arg.__gel_reflection__.type_name
+        elif typename != union_arg.__gel_reflection__.type_name:
             # Reflections of different object types, cannot collapse.
             return None
         if union_arg.__gel_shape__ == "Default" and default_variant is None:

--- a/gel/_internal/_qbmodel/_abstract/_descriptors.py
+++ b/gel/_internal/_qbmodel/_abstract/_descriptors.py
@@ -180,7 +180,7 @@ class ModelFieldDescriptor(_qb.AbstractFieldDescriptor):
                 ptr = owner.__gel_reflection__.pointers[self.__gel_name__]
             except KeyError:
                 # This is a user-defined ad-hoc computed pointer
-                type_ = t.__gel_reflection__.name
+                type_ = t.__gel_reflection__.type_name
             else:
                 type_ = ptr.type
             metadata = _qb.Path(

--- a/gel/_internal/_qbmodel/_abstract/_expressions.py
+++ b/gel/_internal/_qbmodel/_abstract/_expressions.py
@@ -43,7 +43,7 @@ def _get_prefixed_ptr(
     ptrname: str,
     scope: _qb.Scope,
 ) -> tuple[_qb.PathAlias, _qb.Path]:
-    this_type = cls.__gel_reflection__.name
+    this_type = cls.__gel_reflection__.type_name
 
     ptr = getattr(cls, ptrname, Unspecified)
     if ptr is Unspecified:
@@ -121,7 +121,7 @@ def select(
     __operand__: _qb.ExprAlias | None = None,
     **kwargs: bool | _Value,
 ) -> _qb.ShapeOp:
-    this_type = cls.__gel_reflection__.name
+    this_type = cls.__gel_reflection__.type_name
     scope = _qb.Scope()
 
     if __operand__ is not None:
@@ -240,10 +240,9 @@ def update(
     __operand__: _qb.ExprAlias | None = None,
     **kwargs: _Value,
 ) -> _qb.UpdateStmt:
-    this_type = cls.__gel_reflection__.name
     scope = _qb.Scope()
     operand = _qb.edgeql_qb_expr(cls if __operand__ is None else __operand__)
-    this_type = cls.__gel_reflection__.name
+    this_type = cls.__gel_reflection__.type_name
     prefix = _qb.PathPrefix(type_=this_type, scope=scope)
     prefix_alias = _qb.PathAlias(cls, prefix)
 
@@ -443,4 +442,4 @@ def empty_set_if_none(
     val: _T | None,
     type_: type[GelType],
 ) -> _T | _qb.CastOp:
-    return _qb.empty_set_if_none(val, type_=type_.__gel_reflection__.name)
+    return _qb.empty_set_if_none(val, type_=type_.__gel_reflection__.type_name)

--- a/gel/_internal/_qbmodel/_abstract/_globals.py
+++ b/gel/_internal/_qbmodel/_abstract/_globals.py
@@ -11,6 +11,7 @@ from typing_extensions import (
 
 
 from gel._internal import _qb
+from gel._internal._schemapath import SchemaPath
 
 from ._base import GelType
 
@@ -21,6 +22,7 @@ _T = TypeVar("_T", bound=GelType)
 class Global(_qb.GelSchemaMetadata):
     @classmethod
     def global_(cls, tp: type[_T]) -> type[_T]:
+        assert isinstance(cls.__gel_reflection__.name, SchemaPath)
         return _qb.AnnotatedGlobal(  # type: ignore [return-value]
             tp,
             _qb.Global(

--- a/gel/_internal/_qbmodel/_abstract/_globals.py
+++ b/gel/_internal/_qbmodel/_abstract/_globals.py
@@ -11,7 +11,6 @@ from typing_extensions import (
 
 
 from gel._internal import _qb
-from gel._internal._schemapath import SchemaPath
 
 from ._base import GelType
 
@@ -22,11 +21,10 @@ _T = TypeVar("_T", bound=GelType)
 class Global(_qb.GelSchemaMetadata):
     @classmethod
     def global_(cls, tp: type[_T]) -> type[_T]:
-        assert isinstance(cls.__gel_reflection__.name, SchemaPath)
         return _qb.AnnotatedGlobal(  # type: ignore [return-value]
             tp,
             _qb.Global(
                 name=cls.__gel_reflection__.name,
-                type_=tp.__gel_reflection__.name,
+                type_=tp.__gel_reflection__.type_name,
             ),
         )

--- a/gel/_internal/_qbmodel/_abstract/_methods.py
+++ b/gel/_internal/_qbmodel/_abstract/_methods.py
@@ -204,5 +204,5 @@ class BaseGelModel(AbstractGelModel):
 
     @classmethod
     def __edgeql_qb_expr__(cls) -> _qb.Expr:  # pyright: ignore [reportIncompatibleMethodOverride]
-        this_type = cls.__gel_reflection__.name
+        this_type = cls.__gel_reflection__.type_name
         return _qb.SchemaSet(type_=this_type)

--- a/gel/_internal/_qbmodel/_abstract/_primitive.py
+++ b/gel/_internal/_qbmodel/_abstract/_primitive.py
@@ -156,7 +156,7 @@ class AnyEnum(GelScalarType, StrEnum, metaclass=AnyEnumMeta):
     def __edgeql_literal__(self) -> _qb.Literal | _qb.CastOp:
         return _qb.Literal(
             val=str(self),
-            type_=type(self).__gel_reflection__.name,
+            type_=type(self).__gel_reflection__.type_name,
         )
 
 
@@ -232,12 +232,13 @@ class Array(  # type: ignore [misc]
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_array_type_id_and_name(
-            cls.__element_type__.__gel_reflection__.name
+            cls.__element_type__.__gel_reflection__.type_name
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
             id = tid
-            name = tname
+            name = SchemaPath.from_segments("std", "array")
+            type_name = tname
 
         return __gel_reflection__
 
@@ -320,12 +321,13 @@ class Tuple(  # type: ignore[misc]
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_tuple_type_id_and_name(
-            [el.__gel_reflection__.name for el in cls.__element_types__]
+            [el.__gel_reflection__.type_name for el in cls.__element_types__]
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
             id = tid
-            name = tname
+            name = SchemaPath.from_segments("std", "tuple")
+            type_name = tname
 
         return __gel_reflection__
 
@@ -362,12 +364,13 @@ class Range(
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_range_type_id_and_name(
-            cls.__element_type__.__gel_reflection__.name
+            cls.__element_type__.__gel_reflection__.type_name
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
             id = tid
-            name = tname
+            name = SchemaPath.from_segments("std", "range")
+            type_name = tname
 
         return __gel_reflection__
 
@@ -793,7 +796,7 @@ def get_literal_for_scalar(
     else:
         return _qb.CastOp(
             expr=_qb.StringLiteral(val=str(v)),
-            type_=t.__gel_reflection__.name,
+            type_=t.__gel_reflection__.type_name,
         )
 
 

--- a/gel/_internal/_qbmodel/_abstract/_primitive.py
+++ b/gel/_internal/_qbmodel/_abstract/_primitive.py
@@ -232,7 +232,7 @@ class Array(  # type: ignore [misc]
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_array_type_id_and_name(
-            str(cls.__element_type__.__gel_reflection__.name)
+            cls.__element_type__.__gel_reflection__.name
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
@@ -320,7 +320,7 @@ class Tuple(  # type: ignore[misc]
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_tuple_type_id_and_name(
-            str(el.__gel_reflection__.name) for el in cls.__element_types__
+            [el.__gel_reflection__.name for el in cls.__element_types__]
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
@@ -362,7 +362,7 @@ class Range(
     @classmethod
     def __gel_reflection__(cls) -> type[GelPrimitiveType.__gel_reflection__]:  # pyright: ignore [reportIncompatibleVariableOverride]
         tid, tname = _edgeql.get_range_type_id_and_name(
-            str(cls.__element_type__.__gel_reflection__.name)
+            cls.__element_type__.__gel_reflection__.name
         )
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801

--- a/gel/_internal/_qbmodel/_abstract/_primitive.py
+++ b/gel/_internal/_qbmodel/_abstract/_primitive.py
@@ -860,8 +860,8 @@ class UUIDImpl(uuid.UUID):
     ) -> None:
         if hex is not None and isinstance(hex, uuid.UUID):
             super().__init__(
-                int=hex.int,
-                is_safe=hex.is_safe,
+                int=hex.int,  # pyright: ignore[reportArgumentType]
+                is_safe=hex.is_safe,  # pyright: ignore[reportArgumentType]
             )
         else:
             super().__init__(

--- a/gel/_internal/_qbmodel/_abstract/_primitive.py
+++ b/gel/_internal/_qbmodel/_abstract/_primitive.py
@@ -237,7 +237,7 @@ class Array(  # type: ignore [misc]
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
             id = tid
-            name = SchemaPath(tname)
+            name = tname
 
         return __gel_reflection__
 
@@ -325,7 +325,7 @@ class Tuple(  # type: ignore[misc]
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
             id = tid
-            name = SchemaPath(tname)
+            name = tname
 
         return __gel_reflection__
 
@@ -367,7 +367,7 @@ class Range(
 
         class __gel_reflection__(GelPrimitiveType.__gel_reflection__):  # noqa: N801
             id = tid
-            name = SchemaPath(tname)
+            name = tname
 
         return __gel_reflection__
 

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -442,12 +442,12 @@ class HeterogeneousCollectionType(CollectionType):
         object.__setattr__(self, "_mutable_cached", mut)  # noqa: PLC2801
         return mut
 
-    def get_id_and_name(
+    def get_id(
         self,
         element_types: tuple[Type, ...],
         *,
         schema: Mapping[str, Type],
-    ) -> tuple[str, str]:
+    ) -> str:
         cls = type(self)
         raise NotImplementedError(f"{cls.__qualname__}.get_id_and_name()")
 
@@ -506,7 +506,7 @@ class HeterogeneousCollectionType(CollectionType):
                 element_types.append(element_type)
 
         element_types_tup = tuple(element_types)
-        id_, _ = self.get_id_and_name(element_types_tup, schema=schema)
+        id_ = self.get_id(element_types_tup, schema=schema)
         return dataclasses.replace(
             self,
             id=id_,
@@ -696,16 +696,16 @@ class TupleType(_TupleType):
     def kind(self) -> Literal[TypeKind.Tuple]:
         return TypeKind.Tuple
 
-    def get_id_and_name(
+    def get_id(
         self,
         element_types: tuple[Type, ...],
         *,
         schema: Mapping[str, Type],
-    ) -> tuple[str, str]:
+    ) -> str:
         id_, _ = _edgeql.get_tuple_type_id_and_name(
             [el.get_type_name(schema) for el in element_types]
         )
-        return str(id_), "std::tuple"
+        return str(id_)
 
 
 @struct
@@ -725,12 +725,12 @@ class NamedTupleType(_TupleType):
     def kind(self) -> Literal[TypeKind.NamedTuple]:
         return TypeKind.NamedTuple
 
-    def get_id_and_name(
+    def get_id(
         self,
         element_types: tuple[Type, ...],
         *,
         schema: Mapping[str, Type],
-    ) -> tuple[str, str]:
+    ) -> str:
         id_, _ = _edgeql.get_named_tuple_type_id_and_name(
             {
                 el.name: el_type.get_type_name(schema)
@@ -739,7 +739,7 @@ class NamedTupleType(_TupleType):
                 )
             }
         )
-        return str(id_), "std::tuple"
+        return str(id_)
 
 
 def compare_type_generality(a: Type, b: Type, *, schema: Schema) -> int:

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -68,10 +68,6 @@ class Type(SchemaObject, abc.ABC):
         return self.name
 
     @functools.cached_property
-    def edgeql(self) -> str:
-        return self.type_name.as_quoted_schema_name()
-
-    @functools.cached_property
     def generic(self) -> bool:
         sp = self.schemapath
         return (

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -574,7 +574,7 @@ class ArrayType(HomogeneousCollectionType):
 
     def get_id_and_name(self, element_type: Type) -> tuple[str, str]:
         id_, name = _edgeql.get_array_type_id_and_name(element_type.name)
-        return str(id_), name
+        return str(id_), name.as_schema_name()
 
 
 @struct
@@ -600,7 +600,7 @@ class RangeType(HomogeneousCollectionType):
 
     def get_id_and_name(self, element_type: Type) -> tuple[str, str]:
         id_, name = _edgeql.get_range_type_id_and_name(element_type.name)
-        return str(id_), name
+        return str(id_), name.as_schema_name()
 
 
 @struct
@@ -626,7 +626,7 @@ class MultiRangeType(HomogeneousCollectionType):
 
     def get_id_and_name(self, element_type: Type) -> tuple[str, str]:
         id_, name = _edgeql.get_multirange_type_id_and_name(element_type.name)
-        return str(id_), name
+        return str(id_), name.as_schema_name()
 
 
 @struct
@@ -665,7 +665,7 @@ class TupleType(_TupleType):
         id_, name = _edgeql.get_tuple_type_id_and_name(
             el.name for el in element_types
         )
-        return str(id_), name
+        return str(id_), name.as_schema_name()
 
 
 @struct
@@ -694,7 +694,7 @@ class NamedTupleType(_TupleType):
                 )
             }
         )
-        return str(id_), name
+        return str(id_), name.as_schema_name()
 
 
 def compare_type_generality(a: Type, b: Type, *, schema: Schema) -> int:

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -43,6 +43,9 @@ class TypeRef:
     id: str
     name: TypeName
 
+    def __str__(self) -> str:
+        return str(self.name)
+
 
 @sobject
 class Type(SchemaObject, abc.ABC):

--- a/gel/_internal/_reflection/_types.py
+++ b/gel/_internal/_reflection/_types.py
@@ -741,6 +741,15 @@ class NamedTupleType(_TupleType):
         )
         return str(id_)
 
+    def get_type_name(self, schema: Schema) -> TypeName:
+        return ParametricTypeName(
+            self.schemapath,
+            {
+                element.name: schema[element.type_id].get_type_name(schema)
+                for element in self.tuple_elements
+            },
+        )
+
 
 def compare_type_generality(a: Type, b: Type, *, schema: Schema) -> int:
     """Return 1 if a is more general than b, -1 if a is more specific

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -512,7 +512,7 @@ def get_linked_new_objects(obj: GelModel) -> Iterable[GelModel]:
 
 
 def obj_to_name_ql(obj: GelModel) -> str:
-    return type(obj).__gel_reflection__.name.as_quoted_schema_name()
+    return type(obj).__gel_reflection__.type_name.as_quoted_schema_name()
 
 
 def shift_dict_list(inp: dict[str, list[T]]) -> dict[str, T]:
@@ -1476,7 +1476,9 @@ class SaveExecutor:
                 for obj_id, link_ids in obj_links_all.items()
             ]
 
-            tp_ql_name = tp.__gel_reflection__.name.as_quoted_schema_name()
+            tp_ql_name = (
+                tp.__gel_reflection__.type_name.as_quoted_schema_name()
+            )
 
             query = f"""
                 with
@@ -1545,7 +1547,10 @@ class SaveExecutor:
         # Queries must be independent of each other within the same
         # ChangeBatch, so we can sort them to group queries.
         compiled.sort(
-            key=lambda x: (x[0].__gel_reflection__.name, x[1].single_query)
+            key=lambda x: (
+                x[0].__gel_reflection__.type_name,
+                x[1].single_query,
+            )
         )
 
         icomp = iter(compiled)

--- a/gel/_internal/_schemapath.py
+++ b/gel/_internal/_schemapath.py
@@ -225,7 +225,7 @@ class ParametricTypeName:
     args: list[TypeName]
 
     def __str__(self) -> str:
-        return self.as_quoted_schema_name()
+        return self.as_schema_name()
 
     def as_schema_name(self) -> str:
         return (

--- a/gel/_internal/_schemapath.py
+++ b/gel/_internal/_schemapath.py
@@ -149,9 +149,13 @@ class SchemaPath:
     def as_quoted_schema_name(self) -> str:
         return _SEP.join(_edgeql.quote_ident(p) for p in self.parts)
 
-    def as_code(self, clsname: str = "SchemaPath") -> str:
+    def as_python_code(
+        self,
+        schemapath_clsname: str = "SchemaPath",
+        parametrictype_clsname: str = "ParametricTypeName",
+    ) -> str:
         parts = ", ".join(repr(p) for p in self.parts)
-        return f"{clsname}.from_segments({parts})"
+        return f"{schemapath_clsname}.from_segments({parts})"
 
     def as_pathlib_path(self) -> pathlib.Path:
         return pathlib.Path(*self.parts)
@@ -236,6 +240,20 @@ class ParametricTypeName:
             f"{','.join(a.as_quoted_schema_name() for a in self.args)}"
             f">"
         )
+
+    def as_python_code(
+        self,
+        schemapath_clsname: str = "SchemaPath",
+        parametrictype_clsname: str = "ParametricTypeName",
+    ) -> str:
+        type_code = self.type_.as_python_code(
+            schemapath_clsname, parametrictype_clsname
+        )
+        args_code = ', '.join(
+            a.as_python_code(schemapath_clsname, parametrictype_clsname)
+            for a in self.args
+        )
+        return f"{parametrictype_clsname}({type_code}, [{args_code}])"
 
     @property
     def name(self) -> str:

--- a/gel/models/pydantic.py
+++ b/gel/models/pydantic.py
@@ -13,7 +13,7 @@ from pydantic import (
 from gel._internal._deferred_import import DeferredImport
 from gel._internal._edgeql import Cardinality, PointerKind
 from gel._internal._lazyprop import LazyClassProperty
-from gel._internal._schemapath import SchemaPath
+from gel._internal._schemapath import ParametricTypeName, SchemaPath, TypeName
 from gel._internal._typing_dispatch import dispatch_overload
 from gel._internal._utils import UnspecifiedType, Unspecified
 from gel._internal._xmethod import classonlymethod
@@ -162,6 +162,7 @@ __all__ = (
     "OptionalMultiLink",
     "OptionalMultiLinkWithProps",
     "OptionalProperty",
+    "ParametricTypeName",
     "PathAlias",
     "PointerKind",
     "PrefixOp",
@@ -183,6 +184,7 @@ __all__ = (
     "TimeImpl",
     "Tuple",
     "TupleMeta",
+    "TypeName",
     "UUIDImpl",
     "Unspecified",
     "UnspecifiedType",

--- a/tests/test_link_with_props_set.py
+++ b/tests/test_link_with_props_set.py
@@ -53,7 +53,6 @@ class DummyLinkModel(AbstractGelLinkModel):
             "comment": _qb.GelPointerReflection(
                 name="comment",
                 type=SchemaPath("std", "str"),
-                typexpr="std::str",
                 kind=PointerKind.Property,
                 cardinality=Cardinality.AtMostOne,
                 computed=False,

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -53,7 +53,7 @@ from gel._internal import _typing_inspect
 from gel._internal._qbmodel._abstract import LinkSet, LinkWithPropsSet
 from gel._internal._edgeql import Cardinality, PointerKind
 from gel._internal._qbmodel._pydantic._models import GelModel
-from gel._internal._schemapath import SchemaPath
+from gel._internal._schemapath import ParametricTypeName, SchemaPath
 
 from gel._internal._testbase import _models as tb
 
@@ -5487,8 +5487,20 @@ class TestModelGeneratorMain(tb.ModelTestCase):
 
         ntup_t = default.sub.TypeInSub.__gel_reflection__.pointers["ntup"].type
         self.assertEqual(
-            str(ntup_t),
-            "tuple<a:std::str, b:tuple<c:std::int64, d:std::str>>",
+            ntup_t,
+            ParametricTypeName(
+                SchemaPath.from_segments("std", "tuple"),
+                {
+                    'a': SchemaPath.from_segments("std", "str"),
+                    'b': ParametricTypeName(
+                        SchemaPath.from_segments("std", "tuple"),
+                        {
+                            'c': SchemaPath.from_segments("std", "int64"),
+                            'd': SchemaPath.from_segments("std", "str"),
+                        }
+                    ),
+                }
+            ),
         )
 
     def test_modelgen_json_schema_1(self):

--- a/tests/test_schemapath.py
+++ b/tests/test_schemapath.py
@@ -20,7 +20,7 @@ import unittest
 import pathlib
 from typing import Any
 
-from gel._internal._schemapath import SchemaPath
+from gel._internal._schemapath import ParametricTypeName, SchemaPath
 
 
 class TestSchemaPath(unittest.TestCase):
@@ -304,15 +304,39 @@ class TestSchemaPath(unittest.TestCase):
 
     def test_schemapath_as_code(self):
         """Test as_code method."""
-        path = SchemaPath("std::int64")
-        code = path.as_code()
+        type_name = SchemaPath("std::int64")
+        code = type_name.as_python_code()
         self.assertEqual(code, "SchemaPath.from_segments('std', 'int64')")
+
+        type_name = ParametricTypeName(
+            SchemaPath("std", "array"), [SchemaPath("std::int64")]
+        )
+        code = type_name.as_python_code()
+        self.assertEqual(
+            code,
+            "ParametricTypeName("
+            "SchemaPath.from_segments('std', 'array'), "
+            "[SchemaPath.from_segments('std', 'int64')]"
+            ")",
+        )
 
     def test_schemapath_as_code_custom_classname(self):
         """Test as_code method with custom class name."""
-        path = SchemaPath("std::int64")
-        code = path.as_code("MySchemaPath")
+        type_name = SchemaPath("std::int64")
+        code = type_name.as_python_code("MySchemaPath", "MyParametricTypeName")
         self.assertEqual(code, "MySchemaPath.from_segments('std', 'int64')")
+
+        type_name = ParametricTypeName(
+            SchemaPath("std", "array"), [SchemaPath("std::int64")]
+        )
+        code = type_name.as_python_code("MySchemaPath", "MyParametricTypeName")
+        self.assertEqual(
+            code,
+            "MyParametricTypeName("
+            "MySchemaPath.from_segments('std', 'array'), "
+            "[MySchemaPath.from_segments('std', 'int64')]"
+            ")",
+        )
 
     def test_schemapath_as_pathlib_path(self):
         """Test as_pathlib_path method."""

--- a/tests/test_schemapath.py
+++ b/tests/test_schemapath.py
@@ -320,6 +320,21 @@ class TestSchemaPath(unittest.TestCase):
             ")",
         )
 
+        type_name = ParametricTypeName(
+            SchemaPath("std", "tuple"),
+            {'a': SchemaPath("std::int64"), 'b': SchemaPath("std::str")},
+        )
+        code = type_name.as_python_code()
+        self.assertEqual(
+            code,
+            "ParametricTypeName("
+            "SchemaPath.from_segments('std', 'tuple'), {"
+            "'a': SchemaPath.from_segments('std', 'int64'), "
+            "'b': SchemaPath.from_segments('std', 'str')"
+            "}"
+            ")",
+        )
+
     def test_schemapath_as_code_custom_classname(self):
         """Test as_code method with custom class name."""
         type_name = SchemaPath("std::int64")
@@ -335,6 +350,21 @@ class TestSchemaPath(unittest.TestCase):
             "MyParametricTypeName("
             "MySchemaPath.from_segments('std', 'array'), "
             "[MySchemaPath.from_segments('std', 'int64')]"
+            ")",
+        )
+
+        type_name = ParametricTypeName(
+            SchemaPath("std", "tuple"),
+            {'a': SchemaPath("std::int64"), 'b': SchemaPath("std::str")},
+        )
+        code = type_name.as_python_code("MySchemaPath", "MyParametricTypeName")
+        self.assertEqual(
+            code,
+            "MyParametricTypeName("
+            "MySchemaPath.from_segments('std', 'tuple'), {"
+            "'a': MySchemaPath.from_segments('std', 'int64'), "
+            "'b': MySchemaPath.from_segments('std', 'str')"
+            "}"
             ")",
         )
 


### PR DESCRIPTION
Adds to `_schemapath`
- `ParametricTypeName` which represents a type with parameters such as `array<int64>`.
- `TypeName` which is an alias for `SchemaPath | ParametricTypeName`

Then uses these:
- Change query builder expressions to use `TypeName` instead of `SchemaPath` for types.
- Add `type_name` to `GelTypeMetadata.__gel_reflection__`