### PR TITLE
Fix a bunch of range/tuple/array operations

### DIFF
--- a/gel/_internal/ruff.toml
+++ b/gel/_internal/ruff.toml
@@ -59,4 +59,5 @@ extend-ignore = [
     "UP045",   # non-pep604-annotation-optional
     "PLR5501", # collapsible-else-if
     "FURB103", # don't use open and write
+    "E741",    # ambiguous variable names
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ extend-ignore = [
     "E252", # missing-whitespace-around-parameter-equals
     "F541", # f-string-missing-placeholders
     "Q000", # prefer double quotes
+    "E741", # ambiguous variable names
 ]
 
 [tool.ruff.format]

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -6501,9 +6501,17 @@ class TestModelGeneratorMain(tb.ModelTestCase):
         for user in users_with_char:
             self.assertTrue(search_char in user.name.lower())
 
-    @tb.xfail
+    def test_modelgen_operators_range_eq(self):
+        from models.orm import default
+
+        res = self.client.query(
+            default.RangeTest.filter(
+                lambda u: u.int_range == u.int_range
+            )
+        )
+        self.assertEqual(len(res), 1)
+
     def test_modelgen_operators_range_contains(self):
-        """Test string containment and pattern matching operators"""
         from models.orm import default, std
 
         res = self.client.query(

--- a/tests/test_qb.py
+++ b/tests/test_qb.py
@@ -1343,6 +1343,15 @@ class TestQueryBuilder(tb.ModelTestCase):
             self.assertEqual(c.kind, kind)
             self.assertIsInstance(c, default.Chocolate)
 
+    def test_qb_array_agg_01(self):
+        from models.orm import default, std
+
+        agg = std.array_agg(default.User)
+        unpack = std.array_unpack(agg)
+
+        res = self.client.query(unpack)
+        self.assertEqual(len(res), 6)
+
 
 class TestQueryBuilderModify(tb.ModelTestCase):
     """This test suite is for data manipulation using QB."""


### PR DESCRIPTION
Generate `std.range`/`std.tuple`, follownig the approach of #939.

Then, fix calling functions in QB when range[_T_anypoint] or
array[_T_anytype] used, by specifically checking ParametricType
subclasses against GenericAlias[T].